### PR TITLE
fix: invalid instrument names with spaces

### DIFF
--- a/api/metrics/+opentelemetry/+metrics/Meter.m
+++ b/api/metrics/+opentelemetry/+metrics/Meter.m
@@ -37,7 +37,8 @@ classdef Meter < handle
                 ctunit = ""
             end
             import opentelemetry.common.mustBeScalarString
-            ctname = mustBeScalarString(ctname);          
+            ctname = mustBeScalarString(ctname);
+            ctname = strrep(ctname, ' ', '_');
             ctdescription = mustBeScalarString(ctdescription);
             ctunit = mustBeScalarString(ctunit);
             id = obj.Proxy.createCounter(ctname, ctdescription, ctunit);
@@ -56,7 +57,8 @@ classdef Meter < handle
             end
 
             import opentelemetry.common.mustBeScalarString
-            ctname = mustBeScalarString(ctname);          
+            ctname = mustBeScalarString(ctname);
+            ctname = strrep(ctname, ' ', '_');
             ctdescription = mustBeScalarString(ctdescription);
             ctunit = mustBeScalarString(ctunit);
             id = obj.Proxy.createUpDownCounter(ctname, ctdescription, ctunit);
@@ -75,7 +77,8 @@ classdef Meter < handle
             end
 
             import opentelemetry.common.mustBeScalarString
-            hiname = mustBeScalarString(hiname);          
+            hiname = mustBeScalarString(hiname);
+            hiname = strrep(hiname, ' ', '_');
             hidescription = mustBeScalarString(hidescription);
             hiunit = mustBeScalarString(hiunit);
             id = obj.Proxy.createHistogram(hiname, hidescription, hiunit);

--- a/api/metrics/+opentelemetry/+metrics/Meter.m
+++ b/api/metrics/+opentelemetry/+metrics/Meter.m
@@ -38,6 +38,8 @@ classdef Meter < handle
             end
             import opentelemetry.common.mustBeScalarString
             ctname = mustBeScalarString(ctname);
+            % cpp-opentelemetry end does not allow string input with spaces,
+            % replace any spaces with underscores as a temporary fix
             ctname = strrep(ctname, ' ', '_');
             ctdescription = mustBeScalarString(ctdescription);
             ctunit = mustBeScalarString(ctunit);
@@ -58,6 +60,8 @@ classdef Meter < handle
 
             import opentelemetry.common.mustBeScalarString
             ctname = mustBeScalarString(ctname);
+            % cpp-opentelemetry end does not allow string input with spaces,
+            % replace any spaces with underscores as a temporary fix
             ctname = strrep(ctname, ' ', '_');
             ctdescription = mustBeScalarString(ctdescription);
             ctunit = mustBeScalarString(ctunit);
@@ -78,6 +82,8 @@ classdef Meter < handle
 
             import opentelemetry.common.mustBeScalarString
             hiname = mustBeScalarString(hiname);
+            % cpp-opentelemetry end does not allow string input with spaces,
+            % replace any spaces with underscores as a temporary fix
             hiname = strrep(hiname, ' ', '_');
             hidescription = mustBeScalarString(hidescription);
             hiunit = mustBeScalarString(hiunit);

--- a/test/tmetrics.m
+++ b/test/tmetrics.m
@@ -94,16 +94,17 @@ classdef tmetrics < matlab.unittest.TestCase
             ct = mt.createCounter(countername);
 
             % verify if the provider has two metric readers attached
-            reader_size = size(p.MetricReader);
-            verifyEqual(testCase,reader_size(2), 2);
+            reader_count = numel(p.MetricReader);
+            verifyEqual(testCase,reader_count, 2);
 
-            % verify if the json results has two exported instances
+            % verify if the json results has two exported instances after
+            % adding a single value
             ct.add(1);
             pause(2.5);
             clear p;
             results = readJsonResults(testCase);
-            result_size = size(results);
-            verifyEqual(testCase,result_size(2), 2);
+            result_count = numel(results);
+            verifyEqual(testCase,result_count, 2);
         end
 
 
@@ -188,6 +189,7 @@ classdef tmetrics < matlab.unittest.TestCase
             verifyEqual(testCase, dp1.asDouble, vals(1));
             verifyEqual(testCase, dp2.asDouble, vals(2));
         end
+
 
         function testCounterAddAttributes(testCase)
             % test names, added value and attributes in Counter


### PR DESCRIPTION
- temporary fix for issue #28
- change size to numel in "testAddMetricReader" of "tmetrics"