### PR TITLE
Add shutdown and forceflush to Meter Provider

### DIFF
--- a/api/metrics/+opentelemetry/+metrics/MeterProvider.m
+++ b/api/metrics/+opentelemetry/+metrics/MeterProvider.m
@@ -4,7 +4,7 @@ classdef MeterProvider < handle
 
     % Copyright 2023 The MathWorks, Inc.
 
-    properties (Access={?opentelemetry.sdk.metrics.MeterProvider})
+    properties (Access={?opentelemetry.sdk.metrics.MeterProvider, ?opentelemetry.sdk.metrics.Cleanup})
         Proxy   % Proxy object to interface C++ code
     end
 
@@ -57,6 +57,13 @@ classdef MeterProvider < handle
             %
             %    See also OPENTELEMETRY.METRICS.PROVIDER.GETMETERPROVIDER
             obj.Proxy.setMeterProvider();
+        end
+    end
+
+    methods(Access=?opentelemetry.sdk.metrics.Cleanup)
+        function postShutdown(obj)
+            % POSTSHUTDOWN  Handle post-shutdown tasks
+            obj.Proxy.postShutdown();
         end
     end
 end

--- a/api/metrics/include/opentelemetry-matlab/metrics/MeterProviderProxy.h
+++ b/api/metrics/include/opentelemetry-matlab/metrics/MeterProviderProxy.h
@@ -21,6 +21,7 @@ class MeterProviderProxy : public libmexclass::proxy::Proxy {
     MeterProviderProxy(nostd::shared_ptr<metrics_api::MeterProvider> mp) : CppMeterProvider(mp) {
         REGISTER_METHOD(MeterProviderProxy, getMeter);
         REGISTER_METHOD(MeterProviderProxy, setMeterProvider);
+        REGISTER_METHOD(MeterProviderProxy, postShutdown);
     }
 
     // Static make method should only be used by getMeterProvider. It gets the global instance 
@@ -35,6 +36,12 @@ class MeterProviderProxy : public libmexclass::proxy::Proxy {
 
     nostd::shared_ptr<metrics_api::MeterProvider> getInstance() {
         return CppMeterProvider;
+    }
+    
+    void postShutdown(libmexclass::proxy::method::Context& context) {
+	    // Replace meter provider with a no-op instance. Subsequent metrics won't be recorded
+	    nostd::shared_ptr<metrics_api::MeterProvider> noop(new metrics_api::NoopMeterProvider);
+        CppMeterProvider.swap(noop);
     }
 
   protected:

--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/Cleanup.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/Cleanup.m
@@ -1,0 +1,63 @@
+classdef Cleanup
+% Clean up methods for MeterProvider in the API
+
+% Copyright 2023 The MathWorks, Inc.
+
+    methods (Static)
+        function success = shutdown(mp)
+            % SHUTDOWN  Shutdown 
+            %    SUCCESS = SHUTDOWN(MP) shuts down all span processors associated with 
+            %    API meter provider MP and return a logical that indicates 
+            %    whether shutdown was successful.
+            %
+            %    See also FORCEFLUSH
+
+            % return false if input is not the right type
+            if isa(mp, "opentelemetry.metrics.MeterProvider")
+                % convert to MeterProvider class in sdk
+                try
+                    mpsdk = opentelemetry.sdk.metrics.MeterProvider(mp.Proxy);
+                catch 
+                    success = false;
+                    return
+                end
+                success = mpsdk.shutdown;
+                postShutdown(mp);
+            else
+                success = false;
+            end
+        end
+
+        function success = forceFlush(mp, timeout)
+            % FORCEFLUSH Force flush
+            %    SUCCESS = FORCEFLUSH(MP) immediately exports all spans
+            %    that have not yet been exported. Returns a logical that
+            %    indicates whether force flush was successful.
+            %
+            %    SUCCESS = FORCEFLUSH(MP, TIMEOUT) specifies a TIMEOUT
+            %    duration. Force flush must be completed within this time,
+            %    or else it will fail.
+            %
+            %    See also SHUTDOWN
+
+            % return false if input is not the right type
+            if isa(mp, "opentelemetry.metrics.MeterProvider")
+                % convert to MeterProvider class in sdk
+                try
+                    mpsdk = opentelemetry.sdk.metrics.MeterProvider(mp.Proxy);
+                catch
+                    success = false;
+                    return
+                end
+                if nargin < 2 || ~isa(timeout, "duration")
+                    success = mpsdk.forceFlush;
+                else
+                    success = mpsdk.forceFlush(timeout);
+                end
+            else
+                success =  false;
+            end
+        end
+    end
+
+end

--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/Cleanup.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/Cleanup.m
@@ -6,7 +6,7 @@ classdef Cleanup
     methods (Static)
         function success = shutdown(mp)
             % SHUTDOWN  Shutdown 
-            %    SUCCESS = SHUTDOWN(MP) shuts down all span processors associated with 
+            %    SUCCESS = SHUTDOWN(MP) shuts down all metric readers associated with 
             %    API meter provider MP and return a logical that indicates 
             %    whether shutdown was successful.
             %
@@ -30,7 +30,7 @@ classdef Cleanup
 
         function success = forceFlush(mp, timeout)
             % FORCEFLUSH Force flush
-            %    SUCCESS = FORCEFLUSH(MP) immediately exports all spans
+            %    SUCCESS = FORCEFLUSH(MP) immediately exports all metrics
             %    that have not yet been exported. Returns a logical that
             %    indicates whether force flush was successful.
             %

--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
@@ -49,12 +49,12 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
                 % assert(mpproxy.Name == "libmexclass.opentelemetry.MeterProviderProxy");
                 obj.Proxy = libmexclass.proxy.Proxy("Name", ...
                     "libmexclass.opentelemetry.sdk.MeterProviderProxy", ...
-                    "ConstructorArguments", {mpproxy.ID});
+                    "ConstructorArguments", {mpproxy.ID, true});
                 % leave other properties unassigned, they won't be used
             else
                 obj.Proxy = libmexclass.proxy.Proxy("Name", ...
                     "libmexclass.opentelemetry.sdk.MeterProviderProxy", ...
-                    "ConstructorArguments", {reader.Proxy.ID, 0});
+                    "ConstructorArguments", {reader.Proxy.ID, false});
                 obj.MetricReader = reader;
             end
         end

--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
@@ -4,6 +4,10 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
 
     % Copyright 2023 The MathWorks, Inc.
 
+    properties(Access=private)
+        isShutdown (1,1) logical = false
+    end
+
     properties (Access=public)
         MetricReader
     end
@@ -37,10 +41,22 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
             % explicit call to superclass constructor to make it a no-op
             obj@opentelemetry.metrics.MeterProvider("skip");
 
-            obj.Proxy = libmexclass.proxy.Proxy("Name", ...
-                "libmexclass.opentelemetry.sdk.MeterProviderProxy", ...
-                "ConstructorArguments", {reader.Proxy.ID});
-            obj.MetricReader = reader;
+            if isa(reader, "libmexclass.proxy.Proxy")
+                % This code branch is used to support conversion from API
+                % MeterProvider to SDK equivalent, needed internally by
+                % opentelemetry.sdk.metrics.Cleanup
+                mpproxy = reader;  % rename the variable
+                % assert(mpproxy.Name == "libmexclass.opentelemetry.MeterProviderProxy");
+                obj.Proxy = libmexclass.proxy.Proxy("Name", ...
+                    "libmexclass.opentelemetry.sdk.MeterProviderProxy", ...
+                    "ConstructorArguments", {mpproxy.ID});
+                % leave other properties unassigned, they won't be used
+            else
+                obj.Proxy = libmexclass.proxy.Proxy("Name", ...
+                    "libmexclass.opentelemetry.sdk.MeterProviderProxy", ...
+                    "ConstructorArguments", {reader.Proxy.ID, 0});
+                obj.MetricReader = reader;
+            end
         end
         
         function addMetricReader(obj, reader)
@@ -50,6 +66,40 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
         end
             obj.Proxy.addMetricReader(reader.Proxy.ID);
             obj.MetricReader = [obj.MetricReader, reader];
+        end
+
+        function success = shutdown(obj)
+            % SHUTDOWN  Shutdown 
+            %    SUCCESS = SHUTDOWN(MP) shuts down all span processors associated with meter provider MP
+    	    %    and return a logical that indicates whether shutdown was successful.
+            %
+            %    See also FORCEFLUSH
+            if ~obj.isShutdown
+                success = obj.Proxy.shutdown();
+                obj.isShutdown = success;
+            else
+                success = true;
+            end
+        end
+
+        function success = forceFlush(obj, timeout)
+            % FORCEFLUSH Force flush
+            %    SUCCESS = FORCEFLUSH(MP) immediately exports all spans
+            %    that have not yet been exported. Returns a logical that
+            %    indicates whether force flush was successful.
+            %
+            %    SUCCESS = FORCEFLUSH(MP, TIMEOUT) specifies a TIMEOUT
+            %    duration. Force flush must be completed within this time,
+            %    or else it will fail.
+            %
+            %    See also SHUTDOWN
+            if obj.isShutdown
+                success = false;
+            elseif nargin < 2 || ~isa(timeout, "duration")  % ignore timeout if not a duration
+                success = obj.Proxy.forceFlush();
+            else
+                success = obj.Proxy.forceFlush(milliseconds(timeout)*1000); % convert to microseconds
+            end
         end
 
     end

--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
@@ -46,7 +46,7 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
                 % MeterProvider to SDK equivalent, needed internally by
                 % opentelemetry.sdk.metrics.Cleanup
                 mpproxy = reader;  % rename the variable
-                % assert(mpproxy.Name == "libmexclass.opentelemetry.MeterProviderProxy");
+                assert(mpproxy.Name == "libmexclass.opentelemetry.MeterProviderProxy");
                 obj.Proxy = libmexclass.proxy.Proxy("Name", ...
                     "libmexclass.opentelemetry.sdk.MeterProviderProxy", ...
                     "ConstructorArguments", {mpproxy.ID, true});
@@ -70,7 +70,7 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
 
         function success = shutdown(obj)
             % SHUTDOWN  Shutdown 
-            %    SUCCESS = SHUTDOWN(MP) shuts down all span processors associated with meter provider MP
+            %    SUCCESS = SHUTDOWN(MP) shuts down all metric readers associated with meter provider MP
     	    %    and return a logical that indicates whether shutdown was successful.
             %
             %    See also FORCEFLUSH
@@ -84,7 +84,7 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
 
         function success = forceFlush(obj, timeout)
             % FORCEFLUSH Force flush
-            %    SUCCESS = FORCEFLUSH(MP) immediately exports all spans
+            %    SUCCESS = FORCEFLUSH(MP) immediately exports all metrics
             %    that have not yet been exported. Returns a logical that
             %    indicates whether force flush was successful.
             %

--- a/sdk/metrics/include/opentelemetry-matlab/sdk/metrics/MeterProviderProxy.h
+++ b/sdk/metrics/include/opentelemetry-matlab/sdk/metrics/MeterProviderProxy.h
@@ -37,10 +37,16 @@ class MeterProviderProxy : public libmexclass::opentelemetry::MeterProviderProxy
   public:
     MeterProviderProxy(nostd::shared_ptr<metrics_api::MeterProvider> mp) : libmexclass::opentelemetry::MeterProviderProxy(mp) {
         REGISTER_METHOD(MeterProviderProxy, addMetricReader);
+        REGISTER_METHOD(MeterProviderProxy, shutdown);
+        REGISTER_METHOD(MeterProviderProxy, forceFlush);
     }
 
     static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
 
     void addMetricReader(libmexclass::proxy::method::Context& context);
+
+    void shutdown(libmexclass::proxy::method::Context& context);
+
+    void forceFlush(libmexclass::proxy::method::Context& context);
 };
 } // namespace libmexclass::opentelemetry

--- a/sdk/metrics/src/MeterProviderProxy.cpp
+++ b/sdk/metrics/src/MeterProviderProxy.cpp
@@ -11,19 +11,32 @@ namespace libmexclass::opentelemetry::sdk {
 libmexclass::proxy::MakeResult MeterProviderProxy::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
     
     libmexclass::proxy::MakeResult out;
-
-    matlab::data::TypedArray<uint64_t> readerid_mda = constructor_arguments[0];
-    libmexclass::proxy::ID readerid = readerid_mda[0];
-    
-    auto reader = std::static_pointer_cast<PeriodicExportingMetricReaderProxy>(
-	        libmexclass::proxy::ProxyManager::getProxy(readerid))->getInstance();
-    auto p = metrics_sdk::MeterProviderFactory::Create();
-    auto *p_sdk = static_cast<metrics_sdk::MeterProvider *>(p.get());
-    p_sdk->AddMetricReader(std::move(reader));
-  
-    auto p_out = nostd::shared_ptr<metrics_api::MeterProvider>(std::move(p));
-    out = std::make_shared<MeterProviderProxy>(p_out);
-    
+    if (constructor_arguments.getNumberOfElements() == 1)  {
+        // if argument is 1, assume it is an API Meter Provider to support type conversion
+        matlab::data::TypedArray<uint64_t> mpid_mda = constructor_arguments[0];
+        libmexclass::proxy::ID mpid = mpid_mda[0];
+        auto mp = std::static_pointer_cast<libmexclass::opentelemetry::MeterProviderProxy>(
+            libmexclass::proxy::ProxyManager::getProxy(mpid))->getInstance();
+        // check if input can be cast to an SDK Meter Provider 
+        auto mpsdk = dynamic_cast<metrics_sdk::MeterProvider*>(mp.get());
+        if (mpsdk == nullptr) {
+          return libmexclass::error::Error{"opentelemetry:sdk:metrics:Cleanup:UnsetGlobalInstance", 
+          "Clean up operations are not supported if global MeterProvider instance is not set."};
+        }
+        out = std::make_shared<MeterProviderProxy>(nostd::shared_ptr<metrics_api::MeterProvider>(mp));
+    } else {
+        matlab::data::TypedArray<uint64_t> readerid_mda = constructor_arguments[0];
+        libmexclass::proxy::ID readerid = readerid_mda[0];
+        
+        auto reader = std::static_pointer_cast<PeriodicExportingMetricReaderProxy>(
+	            libmexclass::proxy::ProxyManager::getProxy(readerid))->getInstance();
+        auto p = metrics_sdk::MeterProviderFactory::Create();
+        auto *p_sdk = static_cast<metrics_sdk::MeterProvider *>(p.get());
+        p_sdk->AddMetricReader(std::move(reader));
+      
+        auto p_out = nostd::shared_ptr<metrics_api::MeterProvider>(std::move(p));
+        out = std::make_shared<MeterProviderProxy>(p_out);
+    }
     return out;
 }
 
@@ -35,6 +48,26 @@ void MeterProviderProxy::addMetricReader(libmexclass::proxy::method::Context& co
 		    std::static_pointer_cast<PeriodicExportingMetricReaderProxy>(
 			    libmexclass::proxy::ProxyManager::getProxy(readerid))->getInstance());
    return;
+}
+
+void MeterProviderProxy::shutdown(libmexclass::proxy::method::Context& context) {
+    matlab::data::ArrayFactory factory;
+    auto result_mda = factory.createScalar(static_cast<metrics_sdk::MeterProvider&>(*CppMeterProvider).Shutdown());
+    context.outputs[0] = result_mda;
+    nostd::shared_ptr<metrics_api::MeterProvider> noop(new metrics_api::NoopMeterProvider);
+    CppMeterProvider.swap(noop);
+}
+
+void MeterProviderProxy::forceFlush(libmexclass::proxy::method::Context& context) {
+    matlab::data::ArrayFactory factory;
+
+    if (context.inputs.getNumberOfElements() == 0) {
+        context.outputs[0] = factory.createScalar(static_cast<metrics_sdk::MeterProvider&>(*CppMeterProvider).ForceFlush());
+    } else {  // number of inputs > 0
+        matlab::data::TypedArray<double> timeout_mda = context.inputs[0];
+        auto timeout = std::chrono::microseconds(timeout_mda[0]);
+        context.outputs[0] = factory.createScalar(static_cast<metrics_sdk::MeterProvider&>(*CppMeterProvider).ForceFlush(timeout));
+    }
 }
 
 

--- a/sdk/metrics/src/MeterProviderProxy.cpp
+++ b/sdk/metrics/src/MeterProviderProxy.cpp
@@ -11,7 +11,8 @@ namespace libmexclass::opentelemetry::sdk {
 libmexclass::proxy::MakeResult MeterProviderProxy::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
     
     libmexclass::proxy::MakeResult out;
-    if (constructor_arguments.getNumberOfElements() == 1)  {
+    matlab::data::TypedArray<bool> is_api = constructor_arguments[1];
+    if (is_api[0])  {
         // if argument is 1, assume it is an API Meter Provider to support type conversion
         matlab::data::TypedArray<uint64_t> mpid_mda = constructor_arguments[0];
         libmexclass::proxy::ID mpid = mpid_mda[0];

--- a/test/commonSetup.m
+++ b/test/commonSetup.m
@@ -4,5 +4,5 @@ function commonSetup(testCase)
 % Copyright 2023 The MathWorks, Inc.
 
 % start collector
-system(testCase.Otelcol + " --config " + '"' + testCase.OtelConfigFile + '"' + '&');
+system(testCase.Otelcol + " --config " + testCase.OtelConfigFile + '&');
 pause(1);   % give a little time for Collector to start up

--- a/test/commonSetup.m
+++ b/test/commonSetup.m
@@ -4,5 +4,5 @@ function commonSetup(testCase)
 % Copyright 2023 The MathWorks, Inc.
 
 % start collector
-system(testCase.Otelcol + " --config " + testCase.OtelConfigFile + '&');
+system(testCase.Otelcol + " --config " + '"' + testCase.OtelConfigFile + '"' + '&');
 pause(1);   % give a little time for Collector to start up

--- a/test/tmetrics.m
+++ b/test/tmetrics.m
@@ -101,7 +101,7 @@ classdef tmetrics < matlab.unittest.TestCase
             % adding a single value
             ct.add(1);
             pause(2.5);
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             result_count = numel(results);
             verifyEqual(testCase,result_count, 2);
@@ -136,7 +136,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch result
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -180,7 +180,7 @@ classdef tmetrics < matlab.unittest.TestCase
 
             % fetch results
             pause(2.5);
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             dp1 = results{1}.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
             dp2 = results{2}.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -219,7 +219,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch result
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -263,7 +263,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch results
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -303,7 +303,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(5);
 
             % fetch result
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -348,7 +348,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(5);
 
             % fetch result
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -397,7 +397,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(10);
 
             % fetch results
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.histogram.dataPoints;
@@ -454,7 +454,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(10);
 
             % fetch results
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.histogram.dataPoints;
@@ -511,7 +511,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch results
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
+            verifyTrue(testCase, p.shutdown());
             results = readJsonResults(testCase);
             rsize = size(results);
             for i = 1:rsize(2)
@@ -560,7 +560,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             %Shutdown the Meter Provider
-            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(mp));
+            verifyTrue(testCase, mp.shutdown());
 
             % perform test comparisons
             results = readJsonResults(testCase);

--- a/test/tmetrics.m
+++ b/test/tmetrics.m
@@ -538,38 +538,40 @@ classdef tmetrics < matlab.unittest.TestCase
             end
         end
 
-        % function testGetSetMeterProvider(testCase)
-        %     % testGetSetMeterProvider: setting and getting global instance of MeterProvider
-        %     exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-        %     reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-        %         "Interval", seconds(2), "Timeout", seconds(1));
-        %     mp = opentelemetry.sdk.metrics.MeterProvider(reader);
-        %     setMeterProvider(mp);
-        % 
-        %     metername = "foo";
-        %     countername = "bar";
-        %     m = opentelemetry.metrics.getMeter(metername);
-        %     c = createCounter(m, countername);
-        % 
-        %     % create testing value 
-        %     val = 10;
-        % 
-        %     % add value and attributes
-        %     c.add(val);
-        % 
-        %     pause(2.5);
-        % 
-        %     % perform test comparisons
-        %     clear mp;
-        %     results = readJsonResults(testCase);
-        %     results = results{1};
-        %     % check a counter has been created, and check its resource to identify the
-        %     % correct MeterProvider has been used
-        %     verifyNotEmpty(testCase, results);
-        % 
-        %     verifyEqual(testCase, string(results.resourceMetrics.scopeMetrics.metrics.name), countername);
-        %     verifyEqual(testCase, string(results.resourceMetrics.scopeMetrics.scope.name), metername);
-        % end
+        function testGetSetMeterProvider(testCase)
+            % testGetSetMeterProvider: setting and getting global instance of MeterProvider
+            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
+            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
+                "Interval", seconds(2), "Timeout", seconds(1));
+            mp = opentelemetry.sdk.metrics.MeterProvider(reader);
+            setMeterProvider(mp);
+
+            metername = "foo";
+            countername = "bar";
+            m = opentelemetry.metrics.getMeter(metername);
+            c = createCounter(m, countername);
+
+            % create testing value 
+            val = 10;
+
+            % add value and attributes
+            c.add(val);
+
+            pause(2.5);
+
+            % perform test comparisons
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(mp));
+            clear mp;
+
+            results = readJsonResults(testCase);
+            results = results{1};
+            % check a counter has been created, and check its resource to identify the
+            % correct MeterProvider has been used
+            verifyNotEmpty(testCase, results);
+
+            verifyEqual(testCase, string(results.resourceMetrics.scopeMetrics.metrics.name), countername);
+            verifyEqual(testCase, string(results.resourceMetrics.scopeMetrics.scope.name), metername);
+        end
       
     end
 

--- a/test/tmetrics.m
+++ b/test/tmetrics.m
@@ -101,7 +101,7 @@ classdef tmetrics < matlab.unittest.TestCase
             % adding a single value
             ct.add(1);
             pause(2.5);
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             result_count = numel(results);
             verifyEqual(testCase,result_count, 2);
@@ -136,7 +136,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch result
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -180,7 +180,7 @@ classdef tmetrics < matlab.unittest.TestCase
 
             % fetch results
             pause(2.5);
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             dp1 = results{1}.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
             dp2 = results{2}.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -219,7 +219,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch result
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -263,7 +263,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch results
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -303,7 +303,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(5);
 
             % fetch result
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -348,7 +348,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(5);
 
             % fetch result
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -397,7 +397,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(10);
 
             % fetch results
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.histogram.dataPoints;
@@ -454,7 +454,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(10);
 
             % fetch results
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.histogram.dataPoints;
@@ -511,7 +511,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch results
-            clear p;
+            verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(p));
             results = readJsonResults(testCase);
             rsize = size(results);
             for i = 1:rsize(2)
@@ -559,10 +559,10 @@ classdef tmetrics < matlab.unittest.TestCase
 
             pause(2.5);
 
-            % perform test comparisons
+            %Shutdown the Meter Provider
             verifyTrue(testCase, opentelemetry.sdk.metrics.Cleanup.shutdown(mp));
-            clear mp;
 
+            % perform test comparisons
             results = readJsonResults(testCase);
             results = results{1};
             % check a counter has been created, and check its resource to identify the


### PR DESCRIPTION
Adds shutdown and forceflush methods to the meter provider and uses the shutdown method in tmetrics.m. This fixes the issues with the metrics tests where the providers weren't shutdown properly and messed up tests run in the future.