### PR TITLE
Adding Resource Property to MeterProvider

### DIFF
--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
@@ -15,7 +15,7 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
 
     methods
         function obj = MeterProvider(reader, optionnames, optionvalues)
-            % SDK implementation of tracer provider
+            % SDK implementation of meter provider
             %    MP = OPENTELEMETRY.SDK.METRICS.METERPROVIDER creates a meter 
             %    provider that uses a periodic exporting metric reader and default configurations.
             %

--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
@@ -10,9 +10,6 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
 
     properties (Access=public)
         MetricReader
-    end
-
-    properties (Access=public)
         Resource
     end
 

--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/MeterProvider.m
@@ -68,7 +68,7 @@ classdef MeterProvider < opentelemetry.metrics.MeterProvider & handle
                     if strcmp(namei, "Resource")
                         if ~isa(valuei, "dictionary")
                             error("opentelemetry:sdk:metrics:MeterProvider:InvalidResourceType", ...
-                                "Attibutes input must be a dictionary.");
+                                "Resource input must be a dictionary.");
                         end
                         resource = valuei;
                         resourcekeys = keys(valuei);

--- a/sdk/metrics/include/opentelemetry-matlab/sdk/metrics/MeterProviderProxy.h
+++ b/sdk/metrics/include/opentelemetry-matlab/sdk/metrics/MeterProviderProxy.h
@@ -35,7 +35,6 @@ namespace nostd = opentelemetry::nostd;
 namespace metrics_sdk = opentelemetry::sdk::metrics;
 namespace common          = opentelemetry::common;
 namespace otlpexporter = opentelemetry::exporter::otlp;
-namespace resource = opentelemetry::sdk::resource;
 
 
 namespace libmexclass::opentelemetry::sdk {

--- a/sdk/metrics/include/opentelemetry-matlab/sdk/metrics/MeterProviderProxy.h
+++ b/sdk/metrics/include/opentelemetry-matlab/sdk/metrics/MeterProviderProxy.h
@@ -21,15 +21,19 @@
 #include "opentelemetry/sdk/metrics/meter_provider.h"
 #include "opentelemetry/sdk/metrics/meter_provider_factory.h"
 #include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/sdk/resource/resource.h"
+
 
 #include "opentelemetry-matlab/metrics/MeterProxy.h"
 #include "opentelemetry-matlab/metrics/MeterProviderProxy.h"
+#include "opentelemetry-matlab/sdk/common/resource.h"
 
 namespace metrics_api = opentelemetry::metrics;
 namespace nostd = opentelemetry::nostd;
 namespace metrics_sdk = opentelemetry::sdk::metrics;
 namespace common          = opentelemetry::common;
 namespace otlpexporter = opentelemetry::exporter::otlp;
+namespace resource = opentelemetry::sdk::resource;
 
 
 namespace libmexclass::opentelemetry::sdk {

--- a/sdk/metrics/include/opentelemetry-matlab/sdk/metrics/MeterProviderProxy.h
+++ b/sdk/metrics/include/opentelemetry-matlab/sdk/metrics/MeterProviderProxy.h
@@ -22,6 +22,8 @@
 #include "opentelemetry/sdk/metrics/meter_provider_factory.h"
 #include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/metrics/view/view_registry.h"
+#include "opentelemetry/sdk/metrics/view/view_registry_factory.h"
 
 
 #include "opentelemetry-matlab/metrics/MeterProxy.h"

--- a/sdk/metrics/src/MeterProviderProxy.cpp
+++ b/sdk/metrics/src/MeterProviderProxy.cpp
@@ -36,10 +36,12 @@ libmexclass::proxy::MakeResult MeterProviderProxy::make(const libmexclass::proxy
 
         auto reader = std::static_pointer_cast<PeriodicExportingMetricReaderProxy>(
 	            libmexclass::proxy::ProxyManager::getProxy(readerid))->getInstance();
-        auto p = metrics_sdk::MeterProviderFactory::Create();
+        
+        auto view = metrics_sdk::ViewRegistryFactory::Create();
+        auto p = metrics_sdk::MeterProviderFactory::Create(std::move(view), resource_custom);
         auto *p_sdk = static_cast<metrics_sdk::MeterProvider *>(p.get());
         p_sdk->AddMetricReader(std::move(reader));
-      
+
         auto p_out = nostd::shared_ptr<metrics_api::MeterProvider>(std::move(p));
         out = std::make_shared<MeterProviderProxy>(p_out);
     }

--- a/sdk/metrics/src/MeterProviderProxy.cpp
+++ b/sdk/metrics/src/MeterProviderProxy.cpp
@@ -12,7 +12,7 @@ libmexclass::proxy::MakeResult MeterProviderProxy::make(const libmexclass::proxy
     
     libmexclass::proxy::MakeResult out;
     if (constructor_arguments.getNumberOfElements() == 1)  {
-        // if only one input, assume it is an API Tracer Provider to support type conversion
+        // if only one input, assume it is an API Meter Provider to support type conversion
         matlab::data::TypedArray<uint64_t> mpid_mda = constructor_arguments[0];
         libmexclass::proxy::ID mpid = mpid_mda[0];
         auto mp = std::static_pointer_cast<libmexclass::opentelemetry::MeterProviderProxy>(

--- a/sdk/metrics/src/MeterProviderProxy.cpp
+++ b/sdk/metrics/src/MeterProviderProxy.cpp
@@ -15,15 +15,22 @@ libmexclass::proxy::MakeResult MeterProviderProxy::make(const libmexclass::proxy
     matlab::data::TypedArray<uint64_t> readerid_mda = constructor_arguments[0];
     libmexclass::proxy::ID readerid = readerid_mda[0];
     
+    matlab::data::StringArray resourcenames_mda = constructor_arguments[1];
+    size_t nresourceattrs = resourcenames_mda.getNumberOfElements();
+    matlab::data::CellArray resourcevalues_mda = constructor_arguments[2];
+
+    auto resource_custom = createResource(resourcenames_mda, resourcevalues_mda);
+
     auto reader = std::static_pointer_cast<PeriodicExportingMetricReaderProxy>(
 	        libmexclass::proxy::ProxyManager::getProxy(readerid))->getInstance();
-    auto p = metrics_sdk::MeterProviderFactory::Create();
+    auto p = metrics_sdk::MeterProviderFactory::Create(NULL, std::move(resource_custom));
     auto *p_sdk = static_cast<metrics_sdk::MeterProvider *>(p.get());
     p_sdk->AddMetricReader(std::move(reader));
-  
-    auto p_out = nostd::shared_ptr<metrics_api::MeterProvider>(std::move(p));
-    out = std::make_shared<MeterProviderProxy>(p_out);
     
+    auto p_out = nostd::shared_ptr<metrics_api::MeterProvider>(std::move(p));
+
+    out = std::make_shared<MeterProviderProxy>(p_out);
+
     return out;
 }
 

--- a/test/tmetrics_sdk.m
+++ b/test/tmetrics_sdk.m
@@ -1,0 +1,69 @@
+classdef tmetrics_sdk < matlab.unittest.TestCase
+    % tests for metrics SDK
+
+    % Copyright 2023 The MathWorks, Inc.
+
+    properties
+        OtelConfigFile
+        JsonFile
+        PidFile
+        OtelcolName
+        Otelcol
+        ListPid
+        ReadPidList
+        ExtractPid
+        Sigint
+        Sigterm
+    end
+
+    methods (TestClassSetup)
+        function setupOnce(testCase)
+            commonSetupOnce(testCase);
+        end
+    end
+
+    methods (TestMethodTeardown)
+        function teardown(testCase)
+            commonTeardown(testCase);
+        end
+    end
+
+    methods (Test)
+        function testCustomResource(testCase)
+            % testCustomResource: check custom resources are included in
+            % emitted metrics
+            commonSetup(testCase)
+
+            customkeys = ["foo" "bar"];
+            customvalues = [1 5];
+            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
+            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
+                "Interval", seconds(2), "Timeout", seconds(1));
+            mp = opentelemetry.sdk.metrics.MeterProvider(reader, ...
+                "Resource", dictionary(customkeys, customvalues)); 
+            
+            m = getMeter(mp, "mymeter");
+            c = createCounter(m, "mycounter");
+
+            % create testing value 
+            val = 10;
+
+            % add value and attributes
+            c.add(val);
+
+            pause(2.5);
+
+            % perform test comparisons
+            results = readJsonResults(testCase);
+            results = results{1};
+
+            resourcekeys = string({results.resourceMetrics.resource.attributes.key});
+            for i = length(customkeys)
+                idx = find(resourcekeys == customkeys(i));
+                verifyNotEmpty(testCase, idx);
+                verifyEqual(testCase, results.resourceMetrics.resource.attributes(idx).value.doubleValue, customvalues(i));
+            end
+        end
+
+    end
+end


### PR DESCRIPTION
This PR adds the Resource property to MeterProvider. It also creates the test class tmetrics_sdk with one method to test the resource property.