### PR TITLE
Correctly clearing meter providers

### DIFF
--- a/test/tmetrics.m
+++ b/test/tmetrics.m
@@ -101,7 +101,7 @@ classdef tmetrics < matlab.unittest.TestCase
             % adding a single value
             ct.add(1);
             pause(2.5);
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             result_count = numel(results);
             verifyEqual(testCase,result_count, 2);
@@ -136,7 +136,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch result
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -180,7 +180,7 @@ classdef tmetrics < matlab.unittest.TestCase
 
             % fetch results
             pause(2.5);
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             dp1 = results{1}.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
             dp2 = results{2}.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -219,7 +219,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch result
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -263,7 +263,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch results
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -303,7 +303,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(5);
 
             % fetch result
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             results = results{end};
 
@@ -348,7 +348,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(5);
 
             % fetch result
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.sum.dataPoints;
@@ -397,7 +397,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(10);
 
             % fetch results
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.histogram.dataPoints;
@@ -454,7 +454,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(10);
 
             % fetch results
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             results = results{end};
             dp = results.resourceMetrics.scopeMetrics.metrics.histogram.dataPoints;
@@ -511,7 +511,7 @@ classdef tmetrics < matlab.unittest.TestCase
             pause(2.5);
 
             % fetch results
-            verifyTrue(testCase, p.shutdown());
+            clear p;
             results = readJsonResults(testCase);
             rsize = size(results);
             for i = 1:rsize(2)

--- a/test/tmetrics_sdk.m
+++ b/test/tmetrics_sdk.m
@@ -53,6 +53,8 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
 
             pause(2.5);
 
+            clear mp;
+
             % perform test comparisons
             results = readJsonResults(testCase);
             results = results{1};


### PR DESCRIPTION
Minor changes to how meter providers are cleared to fix warnings and errors in the tests.