### PR TITLE
Complex number handling and more code sharing between metric instruments

### DIFF
--- a/api/metrics/+opentelemetry/+metrics/Counter.m
+++ b/api/metrics/+opentelemetry/+metrics/Counter.m
@@ -14,23 +14,7 @@ classdef Counter < opentelemetry.metrics.SynchronousInstrument
        
     methods
         function add(obj, value, varargin)
-            % input value must be a numerical scalar
-            if isnumeric(value) && isscalar(value)
-                if nargin == 2
-                    obj.Proxy.add(value);
-                elseif isa(varargin{1}, "dictionary")
-                    attrkeys = keys(varargin{1});
-                    attrvals = values(varargin{1},"cell");
-                    if all(cellfun(@iscell, attrvals))
-                        attrvals = [attrvals{:}];
-                    end
-                    obj.Proxy.add(value, attrkeys, attrvals);
-                else
-                    attrkeys = [varargin{1:2:length(varargin)}]';
-                    attrvals = [varargin(2:2:length(varargin))]';
-                    obj.Proxy.add(value, attrkeys, attrvals);
-                end
-            end
+            obj.processValue(value, varargin{:});
         end
     end
 end

--- a/api/metrics/+opentelemetry/+metrics/Histogram.m
+++ b/api/metrics/+opentelemetry/+metrics/Histogram.m
@@ -13,23 +13,7 @@ classdef Histogram < opentelemetry.metrics.SynchronousInstrument
        
     methods
         function record(obj, value, varargin)
-            % input value must be a numerical scalar
-            if isnumeric(value) && isscalar(value)
-                if nargin == 2
-                    obj.Proxy.record(value);
-                elseif isa(varargin{1}, "dictionary")
-                    attrkeys = keys(varargin{1});
-                    attrvals = values(varargin{1},"cell");
-                    if all(cellfun(@iscell, attrvals))
-                        attrvals = [attrvals{:}];
-                    end
-                    obj.Proxy.record(value, attrkeys, attrvals);
-                else
-                    attrkeys = [varargin{1:2:length(varargin)}]';
-                    attrvals = [varargin(2:2:length(varargin))]';
-                    obj.Proxy.record(value, attrkeys, attrvals);
-                end
-            end
+            obj.processValue(value, varargin{:});
         end
     end
 end

--- a/api/metrics/+opentelemetry/+metrics/SynchronousInstrument.m
+++ b/api/metrics/+opentelemetry/+metrics/SynchronousInstrument.m
@@ -9,7 +9,7 @@ classdef SynchronousInstrument < handle
         Unit        (1,1) string   
     end
 
-    properties (Access=protected)
+    properties (Access=private)
         Proxy   % Proxy object to interface C++ code
     end
 
@@ -19,6 +19,26 @@ classdef SynchronousInstrument < handle
             obj.Name = name;
             obj.Description = description;
             obj.Unit = unit;
+        end
+
+        function processValue(obj, value, varargin)
+            % input value must be a numerical real scalar
+            if isnumeric(value) && isscalar(value) && isreal(value)
+                if nargin == 2
+                    obj.Proxy.processValue(value);
+                elseif isa(varargin{1}, "dictionary")
+                    attrkeys = keys(varargin{1});
+                    attrvals = values(varargin{1},"cell");
+                    if all(cellfun(@iscell, attrvals))
+                        attrvals = [attrvals{:}];
+                    end
+                    obj.Proxy.processValue(value, attrkeys, attrvals);
+                else
+                    attrkeys = [varargin{1:2:length(varargin)}]';
+                    attrvals = [varargin(2:2:length(varargin))]';
+                    obj.Proxy.processValue(value, attrkeys, attrvals);
+                end
+            end
         end
     end
 end

--- a/api/metrics/+opentelemetry/+metrics/UpDownCounter.m
+++ b/api/metrics/+opentelemetry/+metrics/UpDownCounter.m
@@ -13,23 +13,7 @@ classdef UpDownCounter < opentelemetry.metrics.SynchronousInstrument
        
     methods
         function add(obj, value, varargin)
-            % input value must be a numerical scalar
-            if isnumeric(value) && isscalar(value)
-                if nargin == 2
-                    obj.Proxy.add(value);
-                elseif isa(varargin{1}, "dictionary")
-                    attrkeys = keys(varargin{1});
-                    attrvals = values(varargin{1},"cell");
-                    if all(cellfun(@iscell, attrvals))
-                        attrvals = [attrvals{:}];
-                    end
-                    obj.Proxy.add(value, attrkeys, attrvals);
-                else
-                    attrkeys = [varargin{1:2:length(varargin)}]';
-                    attrvals = [varargin(2:2:length(varargin))]';
-                    obj.Proxy.add(value, attrkeys, attrvals);
-                end
-            end
+            obj.processValue(value, varargin{:});
         end
     end
 end

--- a/api/metrics/include/opentelemetry-matlab/metrics/CounterProxy.h
+++ b/api/metrics/include/opentelemetry-matlab/metrics/CounterProxy.h
@@ -18,10 +18,10 @@ namespace libmexclass::opentelemetry {
 class CounterProxy : public libmexclass::proxy::Proxy {
   public:
     CounterProxy(nostd::shared_ptr<metrics_api::Counter<double> > ct) : CppCounter(ct) {
-       REGISTER_METHOD(CounterProxy, add);
+       REGISTER_METHOD(CounterProxy, processValue);
     }
 
-    void add(libmexclass::proxy::method::Context& context);
+    void processValue(libmexclass::proxy::method::Context& context);
 
   private:
 

--- a/api/metrics/include/opentelemetry-matlab/metrics/HistogramProxy.h
+++ b/api/metrics/include/opentelemetry-matlab/metrics/HistogramProxy.h
@@ -21,10 +21,10 @@ namespace libmexclass::opentelemetry {
 class HistogramProxy : public libmexclass::proxy::Proxy {
   public:
     HistogramProxy(nostd::shared_ptr<metrics_api::Histogram<double> > hist) : CppHistogram(hist) {
-       REGISTER_METHOD(HistogramProxy, record);
+       REGISTER_METHOD(HistogramProxy, processValue);
     }
 
-    void record(libmexclass::proxy::method::Context& context);
+    void processValue(libmexclass::proxy::method::Context& context);
 
   private:
 

--- a/api/metrics/include/opentelemetry-matlab/metrics/UpDownCounterProxy.h
+++ b/api/metrics/include/opentelemetry-matlab/metrics/UpDownCounterProxy.h
@@ -18,10 +18,10 @@ namespace libmexclass::opentelemetry {
 class UpDownCounterProxy : public libmexclass::proxy::Proxy {
   public:
     UpDownCounterProxy(nostd::shared_ptr<metrics_api::UpDownCounter<double> > ct) : CppUpDownCounter(ct) {
-       REGISTER_METHOD(UpDownCounterProxy, add);
+       REGISTER_METHOD(UpDownCounterProxy, processValue);
     }
 
-    void add(libmexclass::proxy::method::Context& context);
+    void processValue(libmexclass::proxy::method::Context& context);
 
   private:
 

--- a/api/metrics/src/CounterProxy.cpp
+++ b/api/metrics/src/CounterProxy.cpp
@@ -12,7 +12,7 @@
 namespace libmexclass::opentelemetry {
 
 
-void CounterProxy::add(libmexclass::proxy::method::Context& context){
+void CounterProxy::processValue(libmexclass::proxy::method::Context& context){
   
     matlab::data::Array value_mda = context.inputs[0];
     double value = static_cast<double>(value_mda[0]);

--- a/api/metrics/src/HistogramProxy.cpp
+++ b/api/metrics/src/HistogramProxy.cpp
@@ -12,7 +12,7 @@
 namespace libmexclass::opentelemetry {
 
 
-void HistogramProxy::record(libmexclass::proxy::method::Context& context){
+void HistogramProxy::processValue(libmexclass::proxy::method::Context& context){
     // Get value
     matlab::data::Array value_mda = context.inputs[0];
     double value = static_cast<double>(value_mda[0]);

--- a/api/metrics/src/UpDownCounterProxy.cpp
+++ b/api/metrics/src/UpDownCounterProxy.cpp
@@ -12,7 +12,7 @@
 namespace libmexclass::opentelemetry {
 
 
-void UpDownCounterProxy::add(libmexclass::proxy::method::Context& context){
+void UpDownCounterProxy::processValue(libmexclass::proxy::method::Context& context){
   
     matlab::data::Array value_mda = context.inputs[0];
     double value = static_cast<double>(value_mda[0]);

--- a/test/tmetrics.m
+++ b/test/tmetrics.m
@@ -15,11 +15,22 @@ classdef tmetrics < matlab.unittest.TestCase
         ExtractPid
         Sigint
         Sigterm
+        ShortIntervalReader
+        DeltaAggregationReader
     end
 
     methods (TestClassSetup)
         function setupOnce(testCase)
             commonSetupOnce(testCase);
+            interval = seconds(2);
+            timeout = seconds(1);
+            testCase.ShortIntervalReader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(...
+                opentelemetry.exporters.otlp.OtlpHttpMetricExporter(), ...
+                "Interval", interval, "Timeout", timeout);
+            testCase.DeltaAggregationReader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(...
+                opentelemetry.exporters.otlp.OtlpHttpMetricExporter(...
+                "PreferredAggregationTemporality", "Delta"), ...
+                "Interval", interval, "Timeout", timeout);
         end
     end
 
@@ -36,91 +47,12 @@ classdef tmetrics < matlab.unittest.TestCase
     end
 
     methods (Test)
-        
-        function testDefaultExporter(testCase)
-            exporter = opentelemetry.exporters.otlp.defaultMetricExporter;
-            verifyEqual(testCase, string(class(exporter)), "opentelemetry.exporters.otlp.OtlpHttpMetricExporter");
-            verifyEqual(testCase, string(exporter.Endpoint), "http://localhost:4318/v1/metrics");
-            verifyEqual(testCase, exporter.Timeout, seconds(10));
-            verifyEqual(testCase, string(exporter.PreferredAggregationTemporality), "cumulative");
-        end
-
-
-        function testExporterBasic(testCase)
-            timeout = seconds(5);
-            temporality = "delta";
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter("Timeout", timeout, ...
-                "PreferredAggregationTemporality", temporality);
-            verifyEqual(testCase, exporter.Timeout, timeout);
-            verifyEqual(testCase, string(exporter.PreferredAggregationTemporality), temporality);
-        end
-
-        
-        function testDefaultReader(testCase)
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader();
-            verifyEqual(testCase, string(class(reader.MetricExporter)), ...
-                "opentelemetry.exporters.otlp.OtlpHttpMetricExporter");
-            verifyEqual(testCase, reader.Interval, minutes(1));
-            verifyEqual(testCase, reader.Interval.Format, 'm');  
-            verifyEqual(testCase, reader.Timeout, seconds(30));
-            verifyEqual(testCase, reader.Timeout.Format, 's');
-        end
-
-
-        function testReaderBasic(testCase)
-            exporter = opentelemetry.exporters.otlp.defaultMetricExporter;
-            interval = hours(1);
-            timeout = minutes(30);
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                "Interval", interval, ...
-                "Timeout", timeout);
-            verifyEqual(testCase, reader.Interval, interval);
-            verifyEqual(testCase, reader.Interval.Format, 'h');  % should not be converted to other units  
-            verifyEqual(testCase, reader.Timeout, timeout);
-            verifyEqual(testCase, reader.Timeout.Format, 'm');
-        end
-
-        
-        function testAddMetricReader(testCase)
-            metername = "foo";
-            countername = "bar";
-            exporter1 = opentelemetry.exporters.otlp.OtlpHttpMetricExporter(...
-                "PreferredAggregationTemporality", "delta");
-            exporter2 = opentelemetry.exporters.otlp.OtlpHttpMetricExporter(...
-                "PreferredAggregationTemporality", "delta");
-            reader1 = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter1, ...,
-                "Interval", seconds(2), "Timeout", seconds(1));
-            reader2 = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter2, ...,
-                "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader1);
-            p.addMetricReader(reader2);
-            mt = p.getMeter(metername);
-            ct = mt.createCounter(countername);
-
-            % verify if the provider has two metric readers attached
-            reader_count = numel(p.MetricReader);
-            verifyEqual(testCase,reader_count, 2);
-
-            % verify if the json results has two exported instances after
-            % adding a single value
-            ct.add(1);
-            pause(2.5);
-            clear p;
-            results = readJsonResults(testCase);
-            result_count = numel(results);
-            verifyEqual(testCase,result_count, 2);
-        end
-
-
         function testCounterBasic(testCase)
             % test names and added value in Counter
             metername = "foo";
             countername = "bar";
             
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
             mt = p.getMeter(metername);
             ct = mt.createCounter(countername);
 
@@ -160,11 +92,7 @@ classdef tmetrics < matlab.unittest.TestCase
             metername = "foo";
             countername = "bar";
             
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter(...
-                "PreferredAggregationTemporality", "Delta");
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.DeltaAggregationReader);
             mt = p.getMeter(metername);
             ct = mt.createCounter(countername);
 
@@ -201,10 +129,7 @@ classdef tmetrics < matlab.unittest.TestCase
             metername = "foo";
             countername = "bar";
 
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
             mt = p.getMeter(metername);
             ct = mt.createCounter(countername);
 
@@ -249,21 +174,20 @@ classdef tmetrics < matlab.unittest.TestCase
         end
 
 
-        function testCounterAddNegative(testCase)
-            % test if counter value remain 0 when added negative value
-            
-            metername = "foo";
-            countername = "bar";
-
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
-            mt = p.getMeter(metername);
-            ct = mt.createCounter(countername);
+        function testCounterInvalidAdd(testCase)
+            % test if counter value remain 0 when added invalid values
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
+            mt = p.getMeter("foo");
+            ct = mt.createCounter("bar");
 
             % add negative value to counter
             ct.add(-1);
+            % add add complex value
+            ct.add(2+3i);
+            % add nonscalar value
+            ct.add(magic(3));
+            % add nonnumerics
+            ct.add("foobar");
             pause(2.5);
 
             % fetch results
@@ -284,10 +208,7 @@ classdef tmetrics < matlab.unittest.TestCase
             metername = "foo";
             countername = "bar";
 
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
             mt = p.getMeter(metername);
             ct = mt.createUpDownCounter(countername);
 
@@ -326,16 +247,9 @@ classdef tmetrics < matlab.unittest.TestCase
 
         function testUpDownCounterAddAttributes(testCase)
             % test names, added value and attributes in UpDownCounter
-
-            metername = "foo";
-            countername = "bar";
-
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
-            mt = p.getMeter(metername);
-            ct = mt.createUpDownCounter(countername);
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
+            mt = p.getMeter("foo");
+            ct = mt.createUpDownCounter("bar");
 
             % create testing value and dictionary
             dict = dictionary("k1","v1","k2",5);
@@ -371,6 +285,26 @@ classdef tmetrics < matlab.unittest.TestCase
 
         end
 
+        function testUpDownCounterInvalidAdd(testCase)
+            % add invalid values to UpDownCounter
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
+            mt = p.getMeter("foo");
+            ct = mt.createUpDownCounter("bar");
+
+            % add add complex value
+            ct.add(2+3i);
+            % add nonscalar value
+            ct.add(magic(3));
+            % add nonnumerics
+            ct.add("foobar");
+            pause(2.5);
+
+            % fetch results
+            clear p;
+            results = readJsonResults(testCase);
+            verifyEmpty(testCase, results);
+        end
+
 
         function testHistogramBasic(testCase)
             % test recorded values in histogram
@@ -378,10 +312,7 @@ classdef tmetrics < matlab.unittest.TestCase
             metername = "foo";
             histname = "bar";
 
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
             mt = p.getMeter(metername);
             hist = mt.createHistogram(histname);
 
@@ -433,15 +364,9 @@ classdef tmetrics < matlab.unittest.TestCase
 
         function testHistogramRecordAttributes(testCase)
             % test recorded values and attributes in histogram
-            metername = "foo";
-            histname = "bar";
-
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
-            mt = p.getMeter(metername);
-            hist = mt.createHistogram(histname);
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
+            mt = p.getMeter("foo");
+            hist = mt.createHistogram("bar");
 
             % create value and attributes for histogram
             dict = dictionary("k1","v1","k2","v2");
@@ -491,18 +416,30 @@ classdef tmetrics < matlab.unittest.TestCase
             verifyEqual(testCase, str2double(counts{len}), sum(vals>bounds(len-1)));
         end
 
+        function testHistogramInvalidValue(testCase)
+            % add invalid values to Histogram
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
+            mt = p.getMeter("foo");
+            h = mt.createHistogram("bar");
+
+            % record add complex value
+            h.record(2+3i);
+            % record nonscalar value
+            h.record(magic(3));
+            % record nonnumerics
+            h.record("foobar");
+            pause(2.5);
+
+            % fetch results
+            clear p;
+            results = readJsonResults(testCase);
+            verifyEmpty(testCase, results);
+        end
 
         function testHistogramDelta(testCase)
-            metername = "foo";
-            histname = "bar";
-
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter(...
-                "PreferredAggregationTemporality", "Delta");
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                                        "Interval", seconds(2), "Timeout", seconds(1));
-            p = opentelemetry.sdk.metrics.MeterProvider(reader);
-            mt = p.getMeter(metername);
-            hist = mt.createHistogram(histname);
+            p = opentelemetry.sdk.metrics.MeterProvider(testCase.DeltaAggregationReader);
+            mt = p.getMeter("foo");
+            hist = mt.createHistogram("bar");
     
             % record value and attributes
             rawvals = [1 6];
@@ -544,10 +481,7 @@ classdef tmetrics < matlab.unittest.TestCase
 
         function testGetSetMeterProvider(testCase)
             % testGetSetMeterProvider: setting and getting global instance of MeterProvider
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                "Interval", seconds(2), "Timeout", seconds(1));
-            mp = opentelemetry.sdk.metrics.MeterProvider(reader);
+            mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
             setMeterProvider(mp);
 
             metername = "foo";

--- a/test/tmetrics_sdk.m
+++ b/test/tmetrics_sdk.m
@@ -14,11 +14,21 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
         ExtractPid
         Sigint
         Sigterm
+        ShortIntervalReader
     end
 
     methods (TestClassSetup)
         function setupOnce(testCase)
             commonSetupOnce(testCase);
+            testCase.ShortIntervalReader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(...
+                opentelemetry.exporters.otlp.OtlpHttpMetricExporter(), ...
+                "Interval", seconds(2), "Timeout", seconds(1));
+        end
+    end
+
+    methods (TestMethodSetup)
+        function setup(testCase)
+            commonSetup(testCase);
         end
     end
 
@@ -29,17 +39,86 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
     end
 
     methods (Test)
+        function testDefaultExporter(testCase)
+            exporter = opentelemetry.exporters.otlp.defaultMetricExporter;
+            verifyEqual(testCase, string(class(exporter)), "opentelemetry.exporters.otlp.OtlpHttpMetricExporter");
+            verifyEqual(testCase, string(exporter.Endpoint), "http://localhost:4318/v1/metrics");
+            verifyEqual(testCase, exporter.Timeout, seconds(10));
+            verifyEqual(testCase, string(exporter.PreferredAggregationTemporality), "cumulative");
+        end
+
+
+        function testExporterBasic(testCase)
+            timeout = seconds(5);
+            temporality = "delta";
+            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter("Timeout", timeout, ...
+                "PreferredAggregationTemporality", temporality);
+            verifyEqual(testCase, exporter.Timeout, timeout);
+            verifyEqual(testCase, string(exporter.PreferredAggregationTemporality), temporality);
+        end
+
+        
+        function testDefaultReader(testCase)
+            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader();
+            verifyEqual(testCase, string(class(reader.MetricExporter)), ...
+                "opentelemetry.exporters.otlp.OtlpHttpMetricExporter");
+            verifyEqual(testCase, reader.Interval, minutes(1));
+            verifyEqual(testCase, reader.Interval.Format, 'm');  
+            verifyEqual(testCase, reader.Timeout, seconds(30));
+            verifyEqual(testCase, reader.Timeout.Format, 's');
+        end
+
+
+        function testReaderBasic(testCase)
+            exporter = opentelemetry.exporters.otlp.defaultMetricExporter;
+            interval = hours(1);
+            timeout = minutes(30);
+            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
+                "Interval", interval, ...
+                "Timeout", timeout);
+            verifyEqual(testCase, reader.Interval, interval);
+            verifyEqual(testCase, reader.Interval.Format, 'h');  % should not be converted to other units  
+            verifyEqual(testCase, reader.Timeout, timeout);
+            verifyEqual(testCase, reader.Timeout.Format, 'm');
+        end
+
+        
+        function testAddMetricReader(testCase)
+            metername = "foo";
+            countername = "bar";
+            exporter1 = opentelemetry.exporters.otlp.OtlpHttpMetricExporter(...
+                "PreferredAggregationTemporality", "delta");
+            exporter2 = opentelemetry.exporters.otlp.OtlpHttpMetricExporter(...
+                "PreferredAggregationTemporality", "delta");
+            reader1 = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter1, ...,
+                "Interval", seconds(2), "Timeout", seconds(1));
+            reader2 = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter2, ...,
+                "Interval", seconds(2), "Timeout", seconds(1));
+            p = opentelemetry.sdk.metrics.MeterProvider(reader1);
+            p.addMetricReader(reader2);
+            mt = p.getMeter(metername);
+            ct = mt.createCounter(countername);
+
+            % verify if the provider has two metric readers attached
+            reader_count = numel(p.MetricReader);
+            verifyEqual(testCase,reader_count, 2);
+
+            % verify if the json results has two exported instances after
+            % adding a single value
+            ct.add(1);
+            pause(2.5);
+            clear p;
+            results = readJsonResults(testCase);
+            result_count = numel(results);
+            verifyEqual(testCase,result_count, 2);
+        end
+
         function testCustomResource(testCase)
             % testCustomResource: check custom resources are included in
             % emitted metrics
-            commonSetup(testCase)
-
             customkeys = ["foo" "bar"];
             customvalues = [1 5];
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                "Interval", seconds(2), "Timeout", seconds(1));
-            mp = opentelemetry.sdk.metrics.MeterProvider(reader, ...
+            mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader, ...
                 "Resource", dictionary(customkeys, customvalues)); 
             
             m = getMeter(mp, "mymeter");
@@ -70,12 +149,7 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
         function testShutdown(testCase)
             % testShutdown: shutdown method should stop exporting
             % of metrics
-            commonSetup(testCase)
-
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                "Interval", seconds(2), "Timeout", seconds(1));
-            mp = opentelemetry.sdk.metrics.MeterProvider(reader);
+            mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
 
             % shutdown the meter provider
             verifyTrue(testCase, shutdown(mp));
@@ -95,13 +169,9 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
 
         function testCleanupSdk(testCase)
             % testCleanupSdk: shutdown an SDK meter provider through the Cleanup class
-            commonSetup(testCase)
 
             % Shut down an SDK meter provider instance
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                "Interval", seconds(2), "Timeout", seconds(1));
-            mp = opentelemetry.sdk.metrics.MeterProvider(reader);
+            mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
 
             % shutdown the meter provider through the Cleanup class
             verifyTrue(testCase, opentelemetry.sdk.common.Cleanup.shutdown(mp));
@@ -121,13 +191,9 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
 
         function testCleanupApi(testCase)
             % testCleanupApi: shutdown an API meter provider through the Cleanup class
-            commonSetup(testCase)
-
+  
             % Shut down an API meter provider instance
-            exporter = opentelemetry.exporters.otlp.OtlpHttpMetricExporter();
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
-                "Interval", seconds(2), "Timeout", seconds(1));
-            mp = opentelemetry.sdk.metrics.MeterProvider(reader);
+            mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
             setMeterProvider(mp);
             clear("mp");
             mp_api = opentelemetry.metrics.Provider.getMeterProvider();


### PR DESCRIPTION
Improve handling of complex numbers (no-op instead of error)
More code sharing between synchronous metric instruments. The "add" method of the counters and the "record" method of the histogram have identical code in the M layer. Combining them into one.
Move SDK related metrics tests into tmetrics_sdk
Push more test setup code into the test setup methods