### PR TITLE
Change sdk class constructors to accept NV pairs without first argument

### DIFF
--- a/sdk/logs/+opentelemetry/+sdk/+logs/BatchLogRecordProcessor.m
+++ b/sdk/logs/+opentelemetry/+sdk/+logs/BatchLogRecordProcessor.m
@@ -10,7 +10,7 @@ classdef BatchLogRecordProcessor < opentelemetry.sdk.logs.LogRecordProcessor
     end
 
     methods
-        function obj = BatchLogRecordProcessor(exporter, optionnames, optionvalues)
+        function obj = BatchLogRecordProcessor(varargin)
             % Batch log record processor creates batches of log records and passes them to an exporter.
             %    BLP = OPENTELEMETRY.SDK.LOGS.BATCHLOGRECORDPROCESSOR creates a 
             %    batch log record processor that uses an OTLP HTTP exporter, which 
@@ -20,7 +20,7 @@ classdef BatchLogRecordProcessor < opentelemetry.sdk.logs.LogRecordProcessor
             %    the log record exporter. Supported log record exporters are OTLP HTTP 
             %    exporter and OTLP gRPC exporter.
             %    
-            %    BLP = OPENTELEMETRY.SDK.LOGS.BATCHLOGRECORDPROCESSOR(EXP, PARAM1, 
+            %    BLP = OPENTELEMETRY.SDK.LOGS.BATCHLOGRECORDPROCESSOR(..., PARAM1, 
             %    VALUE1, PARAM2, VALUE2, ...) specifies optional parameter 
             %    name/value pairs. Parameters are:
             %       "MaximumQueueSize"  - Maximum queue size. After queue
@@ -35,24 +35,18 @@ classdef BatchLogRecordProcessor < opentelemetry.sdk.logs.LogRecordProcessor
             %    OPENTELEMETRY.EXPORTERS.OTLP.OTLPHTTPLOGRECORDEXPORTER, 
             %    OPENTELEMETRY.EXPORTERS.OTLP.OTLPGRPCLOGRECORDEXPORTER, 
             %    OPENTELEMETRY.SDK.LOGS.LOGGERPROVIDER  
-            arguments
-      	       exporter {mustBeA(exporter, "opentelemetry.sdk.logs.LogRecordExporter")} = ...
-                   opentelemetry.exporters.otlp.defaultLogRecordExporter()
-            end
-            arguments (Repeating)
-                optionnames (1,:) {mustBeTextScalar}
-                optionvalues
+
+            if nargin == 0 || ~isa(varargin{1}, "opentelemetry.sdk.logs.LogRecordExporter")
+                exporter = opentelemetry.exporters.otlp.defaultLogRecordExporter;
+            else   % isa(varargin{1}, "opentelemetry.sdk.logs.LogRecordExporter")
+                exporter = varargin{1};
+                varargin(1) = [];
             end
 
             obj = obj@opentelemetry.sdk.logs.LogRecordProcessor(exporter, ...
                 "libmexclass.opentelemetry.sdk.BatchLogRecordProcessorProxy");
 
-            validnames = ["MaximumQueueSize", "ScheduledDelay", "MaximumExportBatchSize"];
-            for i = 1:length(optionnames)
-                namei = validatestring(optionnames{i}, validnames);
-                valuei = optionvalues{i};
-                obj.(namei) = valuei;
-            end
+            obj = obj.processOptions(varargin{:});
         end
 
         function obj = set.MaximumQueueSize(obj, maxqsz)
@@ -84,6 +78,24 @@ classdef BatchLogRecordProcessor < opentelemetry.sdk.logs.LogRecordProcessor
             maxbatch = double(maxbatch);
             obj.Proxy.setMaximumExportBatchSize(maxbatch);
             obj.MaximumExportBatchSize = maxbatch;
+        end
+    end
+
+    methods(Access=private)
+        function obj = processOptions(obj, optionnames, optionvalues)
+            arguments
+      	       obj
+            end
+            arguments (Repeating)
+                optionnames (1,:) {mustBeTextScalar}
+                optionvalues
+            end
+            validnames = ["MaximumQueueSize", "ScheduledDelay", "MaximumExportBatchSize"];
+            for i = 1:length(optionnames)
+                namei = validatestring(optionnames{i}, validnames);
+                valuei = optionvalues{i};
+                obj.(namei) = valuei;
+            end
         end
     end
 end

--- a/sdk/metrics/+opentelemetry/+sdk/+metrics/PeriodicExportingMetricReader.m
+++ b/sdk/metrics/+opentelemetry/+sdk/+metrics/PeriodicExportingMetricReader.m
@@ -2,7 +2,7 @@ classdef PeriodicExportingMetricReader < matlab.mixin.Heterogeneous
 % Periodic exporting metric reader passes collected metrics to an exporter
 % periodically at a fixed time interval.
 
-% Copyright 2023 The MathWorks, Inc.
+% Copyright 2023-2024 The MathWorks, Inc.
 
     properties (GetAccess=?opentelemetry.sdk.metrics.MeterProvider)
         Proxy  % Proxy object to interface C++ code
@@ -18,7 +18,7 @@ classdef PeriodicExportingMetricReader < matlab.mixin.Heterogeneous
     end
 
     methods
-        function obj = PeriodicExportingMetricReader(metricexporter, optionnames, optionvalues)
+        function obj = PeriodicExportingMetricReader(varargin)
             % Periodic exporting metric reader passes collected metrics to
             % an exporter periodically at a fixed time interval.
             %    R = OPENTELEMETRY.SDK.METRICS.PERIODICEXPORTINGMETRICREADER
@@ -31,7 +31,7 @@ classdef PeriodicExportingMetricReader < matlab.mixin.Heterogeneous
             %    are OTLP HTTP exporter and OTLP gRPC exporter.
             %
             %    R = OPENTELEMETRY.SDK.METRICS.PERIODICEXPORTINGMETRICREADER(
-            %    EXP, PARAM1, VALUE1, PARAM2, VALUE2, ...) specifies
+            %    ..., PARAM1, VALUE1, PARAM2, VALUE2, ...) specifies
             %    optional parameter name/value pairs. Parameters are:
             %       "Interval" - Time interval between exports specified as
             %                    a duration. Default is 1 minute.
@@ -42,25 +42,19 @@ classdef PeriodicExportingMetricReader < matlab.mixin.Heterogeneous
             %    See also OPENTELEMETRY.EXPORTERS.OTLP.OTLPHTTPMETRICEXPORTER,
             %    OPENTELEMETRY.EXPORTERS.OTLP.OTLPGRPCMETRICEXPORTER, 
             %    OPENTELEMETRY.SDK.METRICS.METERPROVIDER
-            arguments
-      	       metricexporter {mustBeA(metricexporter, "opentelemetry.sdk.metrics.MetricExporter")} = ...
-                   opentelemetry.exporters.otlp.defaultMetricExporter()
-            end
-            arguments (Repeating)
-                optionnames (1,:) {mustBeTextScalar}
-                optionvalues
+
+            if nargin == 0 || ~isa(varargin{1}, "opentelemetry.sdk.metrics.MetricExporter")
+                metricexporter = opentelemetry.exporters.otlp.defaultMetricExporter;
+            else   % isa(varargin{1}, "opentelemetry.sdk.metrics.MetricExporter")
+                metricexporter = varargin{1};
+                varargin(1) = [];
             end
 
             obj.Proxy = libmexclass.proxy.Proxy("Name", "libmexclass.opentelemetry.sdk.PeriodicExportingMetricReaderProxy" , ...
                 "ConstructorArguments", {metricexporter.Proxy.ID});
             obj.MetricExporter = metricexporter;
 
-            validnames = ["Interval", "Timeout"];
-            for i = 1:length(optionnames)
-                namei = validatestring(optionnames{i}, validnames);
-                valuei = optionvalues{i};
-                obj.(namei) = valuei;
-            end
+            obj = obj.processOptions(varargin{:});
         end
 
         function obj = set.Interval(obj, interval)
@@ -80,6 +74,24 @@ classdef PeriodicExportingMetricReader < matlab.mixin.Heterogeneous
             end
             obj.Proxy.setTimeout(milliseconds(timeout)); %#ok<MCSUP>
             obj.Timeout = timeout;
+        end
+    end
+
+    methods(Access=private)
+        function obj = processOptions(obj, optionnames, optionvalues)
+            arguments
+      	       obj
+            end
+            arguments (Repeating)
+                optionnames (1,:) {mustBeTextScalar}
+                optionvalues
+            end
+            validnames = ["Interval", "Timeout"];
+            for i = 1:length(optionnames)
+                namei = validatestring(optionnames{i}, validnames);
+                valuei = optionvalues{i};
+                obj.(namei) = valuei;
+            end
         end
     end
 end

--- a/test/tlogs_sdk.m
+++ b/test/tlogs_sdk.m
@@ -101,7 +101,7 @@ classdef tlogs_sdk < matlab.unittest.TestCase
 
         function testBatchLogRecordProcessor(testCase)
             % testBatchLogRecordProcessor: setting properties of
-            % BatchRecordProcessor
+            % BatchLogRecordProcessor
             loggername = "foo";
             logseverity = "debug";
             logbody = "bar";
@@ -138,8 +138,7 @@ classdef tlogs_sdk < matlab.unittest.TestCase
             % emitted log record
             customkeys = ["foo" "bar"];
             customvalues = [1 5];
-            lp = opentelemetry.sdk.logs.LoggerProvider(opentelemetry.sdk.logs.SimpleLogRecordProcessor, ...
-                "Resource", dictionary(customkeys, customvalues)); 
+            lp = opentelemetry.sdk.logs.LoggerProvider("Resource", dictionary(customkeys, customvalues)); 
             lg = getLogger(lp, "baz");
             emitLogRecord(lg, "debug", "qux");
 

--- a/test/tmetrics_sdk.m
+++ b/test/tmetrics_sdk.m
@@ -27,7 +27,6 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
             interval = seconds(2);
             timeout = seconds(1);
             testCase.ShortIntervalReader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(...
-                opentelemetry.exporters.otlp.defaultMetricExporter(), ...
                 "Interval", interval, "Timeout", timeout);
             testCase.WaitTime = seconds(interval * 1.25); 
         end
@@ -119,10 +118,9 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
 
 
         function testReaderBasic(testCase)
-            exporter = opentelemetry.exporters.otlp.defaultMetricExporter;
             interval = hours(1);
             timeout = minutes(30);
-            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader(exporter, ...
+            reader = opentelemetry.sdk.metrics.PeriodicExportingMetricReader( ...
                 "Interval", interval, ...
                 "Timeout", timeout);
             verifyEqual(testCase, reader.Interval, interval);


### PR DESCRIPTION
Change constructor of a number of sdk classes to accept option name-value pairs without specifying the first inputs. For example, to specify options for opentelemetry.sdk.trace.TracerProvider, it used to require the first input which is a span processor:
tp = TracerProvider(processor, option1_name, option1_value, option2_name, option2_value, ...)

With this change, the first input can be omitted:
tp = TracerProvider(option1_name, option1_value,  option2_name, option2_value, ...)

The list of changed classes:
opentelemetry.sdk.trace.TracerProvider
opentelemetry.sdk.trace.BatchSpanProcessor
opentelemetry.sdk.metrics.MeterProvider
opentelemetry.sdk.metrics.PeriodicExportingMetricReader
opentelemetry.sdk.logs.LoggerProvider
opentelemetry.sdk.logs.BatchLogRecordProcessor

closes #22