### PR TITLE
Release 1 8 0

### DIFF
--- a/examples/context_propagation/README.md
+++ b/examples/context_propagation/README.md
@@ -44,3 +44,5 @@ In this example, a C++ client calls a MATLAB function hosted on MATLAB Productio
    contextprop_example_client
    ```
 5. Check for expected spans in the OpenTelemetry Collector or in a specified tracing backend.
+
+**NOTE:** In the first call to MATLAB Production Server, it needs to perform a significant amount of loading and initialization, and as a result the client may time out and return an error status. This should only happen in the first call and not in subsequent calls.

--- a/test/tmetrics_sdk.m
+++ b/test/tmetrics_sdk.m
@@ -95,6 +95,7 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
             ct.add(val);
 
             % fetch result
+            forceFlush(p);
             clear("ct", "mt", "p");
             results = jsondecode(fileread(alias));
 


### PR DESCRIPTION
1. Fix a test failure in testOtlpFileExporter in tmetrics_sdk, by force flushing before clearing the meter provider, to make sure the data has been exported to file
2. Add a note to readme in context_propagation example about possible client timeout in the first call
3. Prepare for release 1.8.0

Fixes #156, #23