### PR TITLE
Add unsetTracerProvider and friends

### DIFF
--- a/OtelMatlabProxyFactory.cpp
+++ b/OtelMatlabProxyFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 The MathWorks, Inc.
+// Copyright 2023-2025 The MathWorks, Inc.
 
 #include "OtelMatlabProxyFactory.h"
 
@@ -8,7 +8,10 @@
 //#include "opentelemetry-matlab/trace/ScopeProxy.h"
 #include "opentelemetry-matlab/trace/SpanContextProxy.h"
 #include "opentelemetry-matlab/trace/TraceContextPropagatorProxy.h"
+#include "opentelemetry-matlab/trace/NoOpTracerProviderProxy.h"
+#include "opentelemetry-matlab/metrics/NoOpMeterProviderProxy.h"
 #include "opentelemetry-matlab/logs/LoggerProviderProxy.h"
+#include "opentelemetry-matlab/logs/NoOpLoggerProviderProxy.h"
 #include "opentelemetry-matlab/context/propagation/TextMapCarrierProxy.h"
 #include "opentelemetry-matlab/context/propagation/TextMapPropagatorProxy.h"
 #include "opentelemetry-matlab/context/propagation/CompositePropagatorProxy.h"
@@ -57,6 +60,9 @@ OtelMatlabProxyFactory::make_proxy(const libmexclass::proxy::ClassName& class_na
     REGISTER_PROXY(libmexclass.opentelemetry.SpanProxy, libmexclass::opentelemetry::SpanProxy);
     //REGISTER_PROXY(libmexclass.opentelemetry.ScopeProxy, libmexclass::opentelemetry::ScopeProxy);
     REGISTER_PROXY(libmexclass.opentelemetry.SpanContextProxy, libmexclass::opentelemetry::SpanContextProxy);
+    REGISTER_PROXY(libmexclass.opentelemetry.NoOpTracerProviderProxy, libmexclass::opentelemetry::NoOpTracerProviderProxy);
+    REGISTER_PROXY(libmexclass.opentelemetry.NoOpMeterProviderProxy, libmexclass::opentelemetry::NoOpMeterProviderProxy);
+    REGISTER_PROXY(libmexclass.opentelemetry.NoOpLoggerProviderProxy, libmexclass::opentelemetry::NoOpLoggerProviderProxy);
     REGISTER_PROXY(libmexclass.opentelemetry.TextMapCarrierProxy, libmexclass::opentelemetry::TextMapCarrierProxy);
     REGISTER_PROXY(libmexclass.opentelemetry.ContextProxy, libmexclass::opentelemetry::ContextProxy);
     REGISTER_PROXY(libmexclass.opentelemetry.TokenProxy, libmexclass::opentelemetry::TokenProxy);

--- a/api/logs/+opentelemetry/+logs/+internal/NoOpLoggerProvider.m
+++ b/api/logs/+opentelemetry/+logs/+internal/NoOpLoggerProvider.m
@@ -1,0 +1,20 @@
+classdef NoOpLoggerProvider < handle
+    % A no-op logger provider does nothing and is used to disable logging.
+    % For internal use only.
+
+    % Copyright 2025 The MathWorks, Inc.
+
+    properties (Access=private)
+        Proxy   % Proxy object to interface C++ code
+    end
+
+    methods (Access=?opentelemetry.logs.Provider)
+        function obj = NoOpLoggerProvider()
+            % constructs a no-op LoggerProvider and sets it as the global
+            % instance
+            obj.Proxy = libmexclass.proxy.Proxy("Name", ...
+                "libmexclass.opentelemetry.NoOpLoggerProviderProxy", ...
+                "ConstructorArguments", {});
+        end
+    end
+end

--- a/api/logs/+opentelemetry/+logs/Provider.m
+++ b/api/logs/+opentelemetry/+logs/Provider.m
@@ -1,7 +1,7 @@
 classdef Provider
 % Get and set the global instance of logger provider
 
-% Copyright 2024 The MathWorks, Inc.
+% Copyright 2024-2025 The MathWorks, Inc.
 
     methods (Static)
         function p = getLoggerProvider()
@@ -19,9 +19,21 @@ classdef Provider
             %    OPENTELEMETRY.LOGS.PROVIDER.SETLOGGERPROVIDER(LP) sets
             %    LP as the global instance of logger provider.
             %
-            %    See also OPENTELEMETRY.LOGS.PROVIDER.GETTRACERPROVIDER
+            %    See also OPENTELEMETRY.LOGS.PROVIDER.GETLOGGERPROVIDER, 
+            %    OPENTELEMETRY.LOGS.PROVIDER.UNSETLOGGERPROVIDER
 
             p.setLoggerProvider();
+        end
+
+        function unsetLoggerProvider()
+            % Unset the global instance of logger provider, which disables
+            % logging
+            %    OPENTELEMETRY.LOGS.PROVIDER.UNSETLOGGERPROVIDER() unsets
+            %    the global instance of logger provider.
+            %
+            %    See also OPENTELEMETRY.LOGS.PROVIDER.SETLOGGERPROVIDER
+
+            opentelemetry.logs.internal.NoOpLoggerProvider;
         end
     end
 

--- a/api/logs/include/opentelemetry-matlab/logs/NoOpLoggerProviderProxy.h
+++ b/api/logs/include/opentelemetry-matlab/logs/NoOpLoggerProviderProxy.h
@@ -1,0 +1,29 @@
+// Copyright 2025 The MathWorks, Inc.
+
+#pragma once
+
+#include "libmexclass/proxy/Proxy.h"
+
+#include "opentelemetry/logs/logger_provider.h"
+#include "opentelemetry/logs/provider.h"
+#include "opentelemetry/logs/noop.h"
+
+namespace logs_api = opentelemetry::logs;
+namespace nostd = opentelemetry::nostd;
+
+namespace libmexclass::opentelemetry {
+class NoOpLoggerProviderProxy : public libmexclass::proxy::Proxy {
+  public:
+    NoOpLoggerProviderProxy(nostd::shared_ptr<logs_api::LoggerProvider> lp) : CppLoggerProvider(lp) {
+        // set as global LoggerProvider instance
+        logs_api::Provider::SetLoggerProvider(CppLoggerProvider);
+    } 
+
+    static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+        return std::make_shared<NoOpLoggerProviderProxy>(nostd::shared_ptr<logs_api::LoggerProvider>(new logs_api::NoopLoggerProvider()));
+    }
+
+  protected:
+    nostd::shared_ptr<logs_api::LoggerProvider> CppLoggerProvider;
+};
+} // namespace libmexclass::opentelemetry

--- a/api/metrics/+opentelemetry/+metrics/+internal/NoOpMeterProvider.m
+++ b/api/metrics/+opentelemetry/+metrics/+internal/NoOpMeterProvider.m
@@ -1,0 +1,20 @@
+classdef NoOpMeterProvider < handle
+    % A no-op meter provider does nothing and is used to disable metrics.
+    % For internal use only.
+
+    % Copyright 2025 The MathWorks, Inc.
+
+    properties (Access=private)
+        Proxy   % Proxy object to interface C++ code
+    end
+
+    methods (Access=?opentelemetry.metrics.Provider)
+        function obj = NoOpMeterProvider()
+            % constructs a no-op MeterProvider and sets it as the global
+            % instance
+            obj.Proxy = libmexclass.proxy.Proxy("Name", ...
+                "libmexclass.opentelemetry.NoOpMeterProviderProxy", ...
+                "ConstructorArguments", {});
+        end
+    end
+end

--- a/api/metrics/+opentelemetry/+metrics/Provider.m
+++ b/api/metrics/+opentelemetry/+metrics/Provider.m
@@ -1,7 +1,7 @@
 classdef Provider
 % Get and set the global instance of meter provider
 
-% Copyright 2023 The MathWorks, Inc.
+% Copyright 2023-2025 The MathWorks, Inc.
 
     methods (Static)
         function p = getMeterProvider()
@@ -19,8 +19,20 @@ classdef Provider
             %    OPENTELEMETRY.METRICS.PROVIDER.GETMETERPROVIDER(MP) sets
             %    MP as the global instance of meter provider.
             %
-            %    See also OPENTELEMETRY.METRICS.PROVIDER.GETMETERPROVIDER
+            %    See also OPENTELEMETRY.METRICS.PROVIDER.GETMETERPROVIDER, 
+            %    OPENTELEMETRY.METRICS.PROVIDER.UNSETMETERPROVIDER
             p.setMeterProvider();
+        end
+
+        function unsetMeterProvider()
+            % Unset the global instance of meter provider, which disables
+            % metrics
+            %    OPENTELEMETRY.METRICS.PROVIDER.UNSETMETERPROVIDER() unsets
+            %    the global instance of meter provider.
+            %
+            %    See also OPENTELEMETRY.METRICS.PROVIDER.SETMETERPROVIDER
+
+            opentelemetry.metrics.internal.NoOpMeterProvider;
         end
     end
 

--- a/api/metrics/include/opentelemetry-matlab/metrics/NoOpMeterProviderProxy.h
+++ b/api/metrics/include/opentelemetry-matlab/metrics/NoOpMeterProviderProxy.h
@@ -1,0 +1,29 @@
+// Copyright 2025 The MathWorks, Inc.
+
+#pragma once
+
+#include "libmexclass/proxy/Proxy.h"
+
+#include "opentelemetry/metrics/meter_provider.h"
+#include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/metrics/noop.h"
+
+namespace metrics_api = opentelemetry::metrics;
+namespace nostd = opentelemetry::nostd;
+
+namespace libmexclass::opentelemetry {
+class NoOpMeterProviderProxy : public libmexclass::proxy::Proxy {
+  public:
+    NoOpMeterProviderProxy(nostd::shared_ptr<metrics_api::MeterProvider> mp) : CppMeterProvider(mp) {
+        // set as global MeterProvider instance
+        metrics_api::Provider::SetMeterProvider(CppMeterProvider);
+    } 
+
+    static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+        return std::make_shared<NoOpMeterProviderProxy>(nostd::shared_ptr<metrics_api::MeterProvider>(new metrics_api::NoopMeterProvider()));
+    }
+
+  protected:
+    nostd::shared_ptr<metrics_api::MeterProvider> CppMeterProvider;
+};
+} // namespace libmexclass::opentelemetry

--- a/api/trace/+opentelemetry/+trace/+internal/NoOpTracerProvider.m
+++ b/api/trace/+opentelemetry/+trace/+internal/NoOpTracerProvider.m
@@ -1,0 +1,20 @@
+classdef NoOpTracerProvider < handle
+    % A no-op tracer provider does nothing and is used to disable tracing.
+    % For internal use only.
+
+    % Copyright 2025 The MathWorks, Inc.
+
+    properties (Access=private)
+        Proxy   % Proxy object to interface C++ code
+    end
+
+    methods (Access=?opentelemetry.trace.Provider)
+        function obj = NoOpTracerProvider()
+            % constructs a no-op TracerProvider and sets it as the global
+            % instance
+            obj.Proxy = libmexclass.proxy.Proxy("Name", ...
+                "libmexclass.opentelemetry.NoOpTracerProviderProxy", ...
+                "ConstructorArguments", {});
+        end
+    end
+end

--- a/api/trace/+opentelemetry/+trace/Provider.m
+++ b/api/trace/+opentelemetry/+trace/Provider.m
@@ -1,7 +1,7 @@
 classdef Provider
 % Get and set the global instance of tracer provider
 
-% Copyright 2023 The MathWorks, Inc.
+% Copyright 2023-2025 The MathWorks, Inc.
 
     methods (Static)
         function p = getTracerProvider()
@@ -16,12 +16,24 @@ classdef Provider
 
         function setTracerProvider(p)
             % Set the global instance of tracer provider
-            %    OPENTELEMETRY.TRACE.PROVIDER.GETTRACERPROVIDER(TP) sets
+            %    OPENTELEMETRY.TRACE.PROVIDER.SETTRACERPROVIDER(TP) sets
             %    TP as the global instance of tracer provider.
             %
-            %    See also OPENTELEMETRY.TRACE.PROVIDER.GETTRACERPROVIDER
+            %    See also OPENTELEMETRY.TRACE.PROVIDER.GETTRACERPROVIDER, 
+            %    OPENTELEMETRY.TRACE.PROVIDER.UNSETTRACERPROVIDER
 
             p.setTracerProvider();
+        end
+
+        function unsetTracerProvider()
+            % Unset the global instance of tracer provider, which disables
+            % tracing
+            %    OPENTELEMETRY.TRACE.PROVIDER.UNSETTRACERPROVIDER() unsets
+            %    the global instance of tracer provider.
+            %
+            %    See also OPENTELEMETRY.TRACE.PROVIDER.SETTRACERPROVIDER
+
+            opentelemetry.trace.internal.NoOpTracerProvider;
         end
     end
 

--- a/api/trace/include/opentelemetry-matlab/trace/NoOpTracerProviderProxy.h
+++ b/api/trace/include/opentelemetry-matlab/trace/NoOpTracerProviderProxy.h
@@ -1,0 +1,29 @@
+// Copyright 2025 The MathWorks, Inc.
+
+#pragma once
+
+#include "libmexclass/proxy/Proxy.h"
+
+#include "opentelemetry/trace/tracer_provider.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/trace/noop.h"
+
+namespace trace_api = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+namespace libmexclass::opentelemetry {
+class NoOpTracerProviderProxy : public libmexclass::proxy::Proxy {
+  public:
+    NoOpTracerProviderProxy(nostd::shared_ptr<trace_api::TracerProvider> tp) : CppTracerProvider(tp) {
+        // set as global TracerProvider instance
+        trace_api::Provider::SetTracerProvider(CppTracerProvider);
+    } 
+
+    static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+        return std::make_shared<NoOpTracerProviderProxy>(nostd::shared_ptr<trace_api::TracerProvider>(new trace_api::NoopTracerProvider()));
+    }
+
+  protected:
+    nostd::shared_ptr<trace_api::TracerProvider> CppTracerProvider;
+};
+} // namespace libmexclass::opentelemetry

--- a/test/fixtures/LoggerProviderFixture.m
+++ b/test/fixtures/LoggerProviderFixture.m
@@ -1,0 +1,26 @@
+classdef LoggerProviderFixture < matlab.unittest.fixtures.Fixture
+    % tests fixture for setting the global LoggerProvider instance. 
+
+    % Copyright 2025 The MathWorks, Inc.
+
+    properties (SetAccess=immutable)
+        LoggerProvider (1,1)
+    end
+
+    methods
+        function fixture = LoggerProviderFixture(lp)
+            fixture.LoggerProvider = lp;
+        end
+
+        function setup(fixture)
+            setLoggerProvider(fixture.LoggerProvider);
+            fixture.addTeardown(@opentelemetry.logs.Provider.unsetLoggerProvider);
+        end
+    end
+
+    methods (Access=protected)
+        function tf = isCompatible(fixture1,fixture2)
+            tf = fixture1.LoggerProvider == fixture2.LoggerProvider;
+        end
+    end
+end

--- a/test/fixtures/MeterProviderFixture.m
+++ b/test/fixtures/MeterProviderFixture.m
@@ -1,0 +1,26 @@
+classdef MeterProviderFixture < matlab.unittest.fixtures.Fixture
+    % tests fixture for setting the global MeterProvider instance. 
+
+    % Copyright 2025 The MathWorks, Inc.
+
+    properties (SetAccess=immutable)
+        MeterProvider (1,1)
+    end
+
+    methods
+        function fixture = MeterProviderFixture(mp)
+            fixture.MeterProvider = mp;
+        end
+
+        function setup(fixture)
+            setMeterProvider(fixture.MeterProvider);
+            fixture.addTeardown(@opentelemetry.metrics.Provider.unsetMeterProvider);
+        end
+    end
+
+    methods (Access=protected)
+        function tf = isCompatible(fixture1,fixture2)
+            tf = fixture1.MeterProvider == fixture2.MeterProvider;
+        end
+    end
+end

--- a/test/fixtures/TracerProviderFixture.m
+++ b/test/fixtures/TracerProviderFixture.m
@@ -1,0 +1,26 @@
+classdef TracerProviderFixture < matlab.unittest.fixtures.Fixture
+    % tests fixture for setting the global TracerProvider instance. 
+
+    % Copyright 2025 The MathWorks, Inc.
+
+    properties (SetAccess=immutable)
+        TracerProvider (1,1)
+    end
+
+    methods
+        function fixture = TracerProviderFixture(tp)
+            fixture.TracerProvider = tp;
+        end
+
+        function setup(fixture)
+            setTracerProvider(fixture.TracerProvider);
+            fixture.addTeardown(@opentelemetry.trace.Provider.unsetTracerProvider);
+        end
+    end
+
+    methods (Access=protected)
+        function tf = isCompatible(fixture1,fixture2)
+            tf = fixture1.TracerProvider == fixture2.TracerProvider;
+        end
+    end
+end

--- a/test/performance/logsTest.m
+++ b/test/performance/logsTest.m
@@ -1,7 +1,7 @@
 classdef logsTest < matlab.perftest.TestCase
 % performance tests for logs
 
-% Copyright 2024 The MathWorks, Inc.
+% Copyright 2024-2025 The MathWorks, Inc.
 
     properties
         OtelConfigFile
@@ -18,16 +18,16 @@ classdef logsTest < matlab.perftest.TestCase
     
     methods (TestClassSetup)
         function setupOnce(testCase)
-            % add directory where common setup and teardown code lives
-            utilsfolder = fullfile(fileparts(mfilename('fullpath')), "..", "utils");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(utilsfolder));
+            % add utils and fixtures folder to the path
+            folders = fullfile(fileparts(mfilename('fullpath')), "..", ["utils" "fixtures"]);
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(folders));
 
             commonSetupOnce(testCase);
 
             % create a global logger provider
             import opentelemetry.sdk.logs.*
             lp = LoggerProvider(BatchLogRecordProcessor());
-            setLoggerProvider(lp);
+            testCase.applyFixture(LoggerProviderFixture(lp));
         end
     end
 

--- a/test/performance/metricsTest.m
+++ b/test/performance/metricsTest.m
@@ -18,19 +18,15 @@ classdef metricsTest < matlab.perftest.TestCase
     
     methods (TestClassSetup)
         function setupOnce(testCase)
-            % add directory where common setup and teardown code lives
-            utilsfolder = fullfile(fileparts(mfilename('fullpath')), "..", "utils");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(utilsfolder));
-           
-            % add the callbacks folder to the path
-            callbackfolder = fullfile(fileparts(mfilename('fullpath')), "..", "callbacks");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(callbackfolder));
+            % add utils, callbacks, and fixtures folders to the path
+            folders = fullfile(fileparts(mfilename('fullpath')), "..", ["utils" "callbacks" "fixtures"]);
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(folders));
 
             commonSetupOnce(testCase);
 
             % create a global meter provider
             mp = opentelemetry.sdk.metrics.MeterProvider();
-            setMeterProvider(mp);
+            testCase.applyFixture(MeterProviderFixture(mp)); 
         end
     end
 

--- a/test/performance/traceTest.m
+++ b/test/performance/traceTest.m
@@ -1,7 +1,7 @@
 classdef traceTest < matlab.perftest.TestCase
 % performance tests for tracing
 
-% Copyright 2023-2024 The MathWorks, Inc.
+% Copyright 2023-2025 The MathWorks, Inc.
 
     properties
         OtelConfigFile
@@ -18,16 +18,16 @@ classdef traceTest < matlab.perftest.TestCase
     
     methods (TestClassSetup)
         function setupOnce(testCase)
-            % add directory where common setup and teardown code lives
-            utilsfolder = fullfile(fileparts(mfilename('fullpath')), "..", "utils");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(utilsfolder));
+            % add utils and fixtures folders to the path
+            folders = fullfile(fileparts(mfilename('fullpath')), "..", ["utils" "fixtures"]);
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(folders));
             
             commonSetupOnce(testCase);
 
             % create a global tracer provider
             import opentelemetry.sdk.trace.*
             tp = TracerProvider(BatchSpanProcessor());
-            setTracerProvider(tp);
+            testCase.applyFixture(TracerProviderFixture(tp)); 
         end
     end
 

--- a/test/tautotrace.m
+++ b/test/tautotrace.m
@@ -18,15 +18,15 @@ classdef tautotrace < matlab.unittest.TestCase
 
     methods (TestClassSetup)
         function setupOnce(testCase)
-            % add the utils folder to the path
-            utilsfolder = fullfile(fileparts(mfilename('fullpath')), "utils");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(utilsfolder));
+            % add the utils and fixtures folders to the path
+            folders = fullfile(fileparts(mfilename('fullpath')), ["utils" "fixtures"]);
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(folders));
                         
             commonSetupOnce(testCase);
 
             % configure the global tracer provider
             tp = opentelemetry.sdk.trace.TracerProvider();
-            setTracerProvider(tp);
+            testCase.applyFixture(TracerProviderFixture(tp));
         end
     end
 

--- a/test/tlogs_sdk.m
+++ b/test/tlogs_sdk.m
@@ -1,7 +1,7 @@
 classdef tlogs_sdk < matlab.unittest.TestCase
     % tests for logging SDK (log record processors, exporters, resource)
 
-    % Copyright 2024 The MathWorks, Inc.
+    % Copyright 2024-2025 The MathWorks, Inc.
 
     properties
         OtelConfigFile
@@ -19,9 +19,9 @@ classdef tlogs_sdk < matlab.unittest.TestCase
 
     methods (TestClassSetup)
         function setupOnce(testCase)
-            % add the utils folder to the path
-            utilsfolder = fullfile(fileparts(mfilename('fullpath')), "utils");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(utilsfolder));
+            % add the utils and fixtures folder to the path
+            folders = fullfile(fileparts(mfilename('fullpath')), ["utils" "fixtures"]);
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(folders));
             commonSetupOnce(testCase);
             testCase.ForceFlushTimeout = seconds(2);
         end
@@ -210,8 +210,7 @@ classdef tlogs_sdk < matlab.unittest.TestCase
         function testCleanupApi(testCase)
             % testCleanupApi: shutdown an API logger provider through the Cleanup class  
             lp = opentelemetry.sdk.logs.LoggerProvider();
-            setLoggerProvider(lp);
-            clear("lp");
+            testCase.applyFixture(LoggerProviderFixture(lp));  % set global instance of logger provider
             lp_api = opentelemetry.logs.Provider.getLoggerProvider();
             lg = getLogger(lp_api, "foo");
 

--- a/test/tmetrics.m
+++ b/test/tmetrics.m
@@ -23,14 +23,10 @@ classdef tmetrics < matlab.unittest.TestCase
 
     methods (TestClassSetup)
         function setupOnce(testCase)
-            % add the utils folder to the path
-            utilsfolder = fullfile(fileparts(mfilename('fullpath')), "utils");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(utilsfolder));
+            % add the utils, callbacks, and fixtures folders to the path
+            folders = fullfile(fileparts(mfilename('fullpath')), ["utils" "callbacks" "fixtures"]);
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(folders));
             commonSetupOnce(testCase);
-            
-            % add the callbacks folder to the path
-            callbackfolder = fullfile(fileparts(mfilename('fullpath')), "callbacks");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(callbackfolder));
 
             interval = seconds(2);
             timeout = seconds(1);
@@ -571,13 +567,10 @@ classdef tmetrics < matlab.unittest.TestCase
         end
 
         function testGetSetMeterProvider(testCase)
-            % testGetSetMeterProvider: setting and getting global instance of MeterProvider
-                        
-            % suppress internal warning logs about repeated shutdown
-            nologs = SuppressInternalLogs; %#ok<NASGU>
+            % testGetSetMeterProvider: setting, getting, and unsetting global instance of MeterProvider
 
             mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
-            setMeterProvider(mp);
+            testCase.applyFixture(MeterProviderFixture(mp));  % set MeterProvider global instance
 
             metername = "foo";
             countername = "bar";
@@ -592,8 +585,12 @@ classdef tmetrics < matlab.unittest.TestCase
 
             pause(testCase.WaitTime);
 
-            %Shutdown the Meter Provider
-            verifyTrue(testCase, mp.shutdown());
+            %Unset the global meter provider and generate more metrics
+            opentelemetry.metrics.Provider.unsetMeterProvider;
+            m = opentelemetry.metrics.getMeter(metername);
+            countername2 = "quux";
+            c2 = createCounter(m, countername2);
+            c2.add(val);
 
             % perform test comparisons
             results = readJsonResults(testCase);
@@ -601,6 +598,9 @@ classdef tmetrics < matlab.unittest.TestCase
             % check a counter has been created, and check its resource to identify the
             % correct MeterProvider has been used
             verifyNotEmpty(testCase, results);
+            
+            % check that only one metric is generated
+            verifyNumElements(testCase, results.resourceMetrics.scopeMetrics.metrics, 1);
 
             verifyEqual(testCase, string(results.resourceMetrics.scopeMetrics.metrics.name), countername);
             verifyEqual(testCase, string(results.resourceMetrics.scopeMetrics.scope.name), metername);

--- a/test/tmetrics.m
+++ b/test/tmetrics.m
@@ -569,6 +569,9 @@ classdef tmetrics < matlab.unittest.TestCase
         function testGetSetMeterProvider(testCase)
             % testGetSetMeterProvider: setting, getting, and unsetting global instance of MeterProvider
 
+            % suppress internal warning logs about repeated shutdown
+            nologs = SuppressInternalLogs; %#ok<NASGU>
+
             mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
             testCase.applyFixture(MeterProviderFixture(mp));  % set MeterProvider global instance
 
@@ -585,6 +588,9 @@ classdef tmetrics < matlab.unittest.TestCase
 
             pause(testCase.WaitTime);
 
+            %Shutdown the Meter Provider
+            verifyTrue(testCase, mp.shutdown());
+            
             %Unset the global meter provider and generate more metrics
             opentelemetry.metrics.Provider.unsetMeterProvider;
             m = opentelemetry.metrics.getMeter(metername);

--- a/test/tmetrics_sdk.m
+++ b/test/tmetrics_sdk.m
@@ -522,6 +522,7 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
             % Shut down an API meter provider instance
             mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
             testCase.applyFixture(MeterProviderFixture(mp));  % set MeterProvider global instance
+            clear("mp");
             mp_api = opentelemetry.metrics.Provider.getMeterProvider();
 
             % shutdown the API meter provider through the Cleanup class

--- a/test/tmetrics_sdk.m
+++ b/test/tmetrics_sdk.m
@@ -1,7 +1,7 @@
 classdef tmetrics_sdk < matlab.unittest.TestCase
     % tests for metrics SDK
 
-    % Copyright 2023-2024 The MathWorks, Inc.
+    % Copyright 2023-2025 The MathWorks, Inc.
 
     properties
         OtelConfigFile
@@ -20,9 +20,9 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
 
     methods (TestClassSetup)
         function setupOnce(testCase)
-            % add the utils folder to the path
-            utilsfolder = fullfile(fileparts(mfilename('fullpath')), "utils");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(utilsfolder));
+            % add the utils and fixtures folders to the path
+            folders = fullfile(fileparts(mfilename('fullpath')), ["utils" "fixtures"]);
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(folders));
             commonSetupOnce(testCase);
             interval = seconds(2);
             timeout = seconds(1);
@@ -521,8 +521,7 @@ classdef tmetrics_sdk < matlab.unittest.TestCase
 
             % Shut down an API meter provider instance
             mp = opentelemetry.sdk.metrics.MeterProvider(testCase.ShortIntervalReader);
-            setMeterProvider(mp);
-            clear("mp");
+            testCase.applyFixture(MeterProviderFixture(mp));  % set MeterProvider global instance
             mp_api = opentelemetry.metrics.Provider.getMeterProvider();
 
             % shutdown the API meter provider through the Cleanup class

--- a/test/ttrace_sdk.m
+++ b/test/ttrace_sdk.m
@@ -1,7 +1,7 @@
 classdef ttrace_sdk < matlab.unittest.TestCase
     % tests for tracing SDK (span processors, exporters, samplers, resource)
 
-    % Copyright 2023-2024 The MathWorks, Inc.
+    % Copyright 2023-2025 The MathWorks, Inc.
 
     properties
         OtelConfigFile
@@ -19,9 +19,9 @@ classdef ttrace_sdk < matlab.unittest.TestCase
 
     methods (TestClassSetup)
         function setupOnce(testCase)
-            % add the utils folder to the path
-            utilsfolder = fullfile(fileparts(mfilename('fullpath')), "utils");
-            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(utilsfolder));
+            % add the utils and fixtures folders to the path
+            folders = fullfile(fileparts(mfilename('fullpath')), ["utils" "fixtures"]);
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(folders));
             commonSetupOnce(testCase);
             testCase.ForceFlushTimeout = seconds(2);
         end
@@ -276,8 +276,7 @@ classdef ttrace_sdk < matlab.unittest.TestCase
         function testCleanupApi(testCase)
             % testCleanupApi: shutdown an API tracer provider through the Cleanup class  
             tp = opentelemetry.sdk.trace.TracerProvider();
-            setTracerProvider(tp);
-            clear("tp");
+            testCase.applyFixture(TracerProviderFixture(tp));  % set TracerProvider global instance
             tp_api = opentelemetry.trace.Provider.getTracerProvider();
             tr = getTracer(tp_api, "foo");
 


### PR DESCRIPTION
Add a new static method unsetTracerProvider to opentelemetry.trace.Provider, which unsets the global tracer provider and disables tracing from new tracers.
Similarly, add unsetMeterProvider and unsetLoggerProvider for metrics and logs.
Use the new methods in tests for clean up. Tests that set the global provider previously drool the provider change (output state is not the same as input state). With this additional cleanup, the state of each test after running can be identical to before running. 
Fixes #162 
 