### PR TITLE
Update OpenSSL to be compatible with cmake 4.0 on Mac

### DIFF
--- a/.github/workflows/build_and_test_full.yml
+++ b/.github/workflows/build_and_test_full.yml
@@ -148,6 +148,8 @@ jobs:
                 products: MATLAB_Compiler MATLAB_Compiler_SDK
             - name: Build OpenTelemetry-Matlab
               working-directory: opentelemetry-matlab
+              env:
+                 CMAKE_POLICY_VERSION_MINIMUM: 3.5   # required by upb because its cmake requirement is not compatible with cmake 4 
               run: |
                   cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_EXAMPLES=ON -DWITH_OTLP_GRPC=ON -DUSE_BATCH_FOR_MCC=ON -DOTEL_MATLAB_VERSION=${{ needs.get_version.outputs.version }} -DCMAKE_INSTALL_PREFIX=${{ env.OPENTELEMETRY_MATLAB_INSTALL }}
                   cmake --build build --config Release --target install

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -85,6 +85,8 @@ jobs:
                 products: MATLAB_Compiler
             - name: Build OpenTelemetry-Matlab
               working-directory: opentelemetry-matlab
+              env:
+                 CMAKE_POLICY_VERSION_MINIMUM: 3.5   # required by upb because its cmake requirement is not compatible with cmake 4 
               run: |
                   cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_OTLP_GRPC=ON -DWITH_OTLP_FILE=ON -DOTEL_MATLAB_VERSION=${{ github.ref_name }} -DCMAKE_INSTALL_PREFIX=${{ env.OPENTELEMETRY_MATLAB_INSTALL }}
                   cmake --build build --config Release --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
 
    set(VCPKG_FETCH_CONTENT_NAME vcpkg)
    set(VCPKG_GIT_REPOSITORY "https://github.com/microsoft/vcpkg.git")
-   set(VCPKG_GIT_TAG "b02e341")
+   set(VCPKG_GIT_TAG "ce613c4")
    FetchContent_Declare(
        ${VCPKG_FETCH_CONTENT_NAME}
        GIT_REPOSITORY ${VCPKG_GIT_REPOSITORY}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,7 +20,10 @@
         "abseil",
         "c-ares",
         "re2",
-        "openssl",
+	{
+	  "name": "openssl",
+	  "version>=": "3.5.0"
+	},
         "upb"
       ]
     }


### PR DESCRIPTION
This change is in response to GitHub runners changing to use cmake 4.0 on Mac platforms. 
A previous change to update the version of libmexclass turns out is not enough. 
We also need to update the version of OpenSSL and add an environment variable CMAKE_POLICY_VERSION_MINIMUM such that upb can build with CMake 4.0.
Fixes #211 