### PR TITLE
stop Git from recursively cloning submodules when cloning gRPC

### DIFF
--- a/.github/workflows/build_and_test_full.yml
+++ b/.github/workflows/build_and_test_full.yml
@@ -5,7 +5,6 @@ on:
     push:
       branches: 
         - main
-        - grpc
 env:
   MLM_LICENSE_TOKEN: ${{ secrets.MLM_LICENSE_TOKEN }}
 jobs:

--- a/.github/workflows/build_and_test_simple.yml
+++ b/.github/workflows/build_and_test_simple.yml
@@ -6,7 +6,6 @@ on:
       branches-ignore:
         - 'main'
         - '[0-9]+.[0-9]+.[0-9]+'
-        - 'grpc'
 env:
   MLM_LICENSE_TOKEN: ${{ secrets.MLM_LICENSE_TOKEN }}
 jobs:


### PR DESCRIPTION
The recursive cloning causes a problem on Windows due to long path and file names