### PR TITLE
Add warning for parallel builds

### DIFF
--- a/instrumentation/buildtool/+matlab/+buildtool/+plugins/OpenTelemetryPlugin.m
+++ b/instrumentation/buildtool/+matlab/+buildtool/+plugins/OpenTelemetryPlugin.m
@@ -12,7 +12,7 @@ classdef OpenTelemetryPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
             p = gcp("nocreate");
             if ~isempty(p)
                 warning("opentelemetry:buildtool:OpenTelemetryPlugin:NoParallelEmit", ...
-                    "Tasks run on parallel workers will not emit telemetry data");
+                    "Tasks executed on parallel workers do not emit telemetry data.");
             end
 
             % Configure by attaching to span if passed in via environment

--- a/instrumentation/buildtool/+matlab/+buildtool/+plugins/OpenTelemetryPlugin.m
+++ b/instrumentation/buildtool/+matlab/+buildtool/+plugins/OpenTelemetryPlugin.m
@@ -4,6 +4,17 @@ classdef OpenTelemetryPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
     methods(Access = protected)
         function runBuild(plugin, pluginData)
+            % Warn users that tasks on workers will not emit telemetry data
+            % if a pool is open. 
+            % 
+            % Imperfect detection of parallel builds but
+            % the impact of a false positive is very low
+            p = gcp("nocreate");
+            if ~isempty(p)
+                warning("opentelemetry:buildtool:OpenTelemetryPlugin:NoParallelEmit", ...
+                    "Tasks run on parallel workers will not emit telemetry data");
+            end
+
             % Configure by attaching to span if passed in via environment
             % variable, and propagating baggage
             configureOTel();
@@ -56,10 +67,6 @@ classdef OpenTelemetryPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
         end
 
         function runTask(plugin, pluginData)
-            % TODO:
-            %  - buildtool.task.outputs
-            %  - buildtool.task.inputs
-
             % Definitions
             task = pluginData.TaskGraph.Tasks;
             taskName = pluginData.Name;


### PR DESCRIPTION
Parallel workers currently do not emit telemetry data, and there are a few technical hurdles to implementing that behavior. After some consideration, I've decided that the best approach moving forward is to warn the user of this behavior, but keep it as it is today so that we can still provide users with telemetry data related to the overall build result and all tasks which ran on the client.

Unfortunately, the framework currently does not have a way to determine from within a plugin whether the build is running in parallel or not. As such, I check whether a parpool is open. This approach will never result in false negatives, but may occasionally result in false positives. Because the impact of a false positive is very low here, this seems acceptable to me but I welcome feedback from others on that decision.