### PR TITLE
Ensure that PCT is installed and licenesed before checking if a pool …

### DIFF
--- a/.github/workflows/build_and_test_full.yml
+++ b/.github/workflows/build_and_test_full.yml
@@ -5,7 +5,7 @@ on:
     push:
       branches: 
         - main
-        - mbt-plugin
+        - pct-unavailable-fix
 env:
   MLM_LICENSE_TOKEN: ${{ secrets.MLM_LICENSE_TOKEN }}
 jobs:

--- a/instrumentation/buildtool/+matlab/+buildtool/+plugins/OpenTelemetryPlugin.m
+++ b/instrumentation/buildtool/+matlab/+buildtool/+plugins/OpenTelemetryPlugin.m
@@ -9,10 +9,12 @@ classdef OpenTelemetryPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
             % 
             % Imperfect detection of parallel builds but
             % the impact of a false positive is very low
-            p = gcp("nocreate");
-            if ~isempty(p)
-                warning("opentelemetry:buildtool:OpenTelemetryPlugin:NoParallelEmit", ...
-                    "Tasks executed on parallel workers do not emit telemetry data.");
+            if matlab.internal.parallel.isPCTInstalled && matlab.internal.parallel.isPCTLicensed
+                p = gcp("nocreate");
+                if ~isempty(p)
+                    warning("opentelemetry:buildtool:OpenTelemetryPlugin:NoParallelEmit", ...
+                        "Tasks executed on parallel workers do not emit telemetry data.");
+                end
             end
 
             % Configure by attaching to span if passed in via environment


### PR DESCRIPTION
…is open.

This change fixes the current test failures by ensuring that PCT is installed and available before checking if there's an active pool. I'll revert the change to the workflow file after the checks for this PR finish.