### PR TITLE
Reset to main, filter testWebread on macos-15-intel

### DIFF
--- a/.github/workflows/build_and_test_full.yml
+++ b/.github/workflows/build_and_test_full.yml
@@ -135,6 +135,7 @@ jobs:
         needs: get_version
         env:
             OPENTELEMETRY_MATLAB_INSTALL: "${{ github.workspace }}/otel_matlab_install"
+            OPENTELEMETRY_MAC_VERSION: "${{ matrix.os }}"
         steps:
             - name: Download OpenTelemetry-Matlab source
               uses: actions/checkout@v3

--- a/.github/workflows/build_and_test_simple.yml
+++ b/.github/workflows/build_and_test_simple.yml
@@ -97,6 +97,7 @@ jobs:
         needs: get_version
         env:
             OPENTELEMETRY_MATLAB_INSTALL: "${{ github.workspace }}/otel_matlab_install"
+            OPENTELEMETRY_MAC_VERSION: "${{ matrix.os }}"
         steps:
             - name: Download OpenTelemetry-Matlab source
               uses: actions/checkout@v3

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -185,6 +185,7 @@ jobs:
             os: [macos-15-intel, macos-14]   # runs on Mac with both Intel (macos-15-intel) and Apple Silicon (macos-14) processors
         env:
             OPENTELEMETRY_MATLAB_INSTALL: "${{ github.workspace }}/otel_matlab_install"
+            OPENTELEMETRY_MAC_VERSION: "${{ matrix.os }}"
         steps:
             - name: Download OpenTelemetry-Matlab source
               uses: actions/checkout@v3

--- a/test/texamples.m
+++ b/test/texamples.m
@@ -256,6 +256,9 @@ classdef texamples < matlab.unittest.TestCase
         function testWebread(testCase)
             % testWebread: webread_example in examples/webread folder
 
+            % filter test on MacOS-15-Intel
+            macIntel = ismac && contains(getenv("OPENTELEMETRY_MAC_VERSION"),"intel");
+            testCase.assumeFalse(macIntel,"Filtered test due to failures launching CppServer on macos-15-intel")
             % use default location to look for server, filter out if not
             % found
             serverfolder = fullfile(fileparts(mfilename('fullpath')), "..", "build", "examples", "webread");


### PR DESCRIPTION
Added environment variable in workflows to be able to check the version of macos being run. Used the environment variable to filter texamples/testWebread related to issues in #205 causing this test to fail specifically on macos-15-intel.